### PR TITLE
Diagnose silent sign in failure

### DIFF
--- a/src/app/(auth)/auth/page.tsx
+++ b/src/app/(auth)/auth/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { getSupabaseBrowserClient } from '@/lib/supabase/client'
 
 export const dynamic = 'force-dynamic'
@@ -10,15 +11,26 @@ export default function AuthPage() {
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const router = useRouter()
 
   async function handleSignIn(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
     setError(null)
     const supabase = getSupabaseBrowserClient()
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
-    if (error) setError(error.message)
-    setLoading(false)
+    try {
+      const { error } = await supabase.auth.signInWithPassword({ email, password })
+      if (error) {
+        setError(error.message)
+      } else {
+        router.replace('/')
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unexpected error during sign-in'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation'
-
-export default function Home() {
-  redirect('/auth')
-}


### PR DESCRIPTION
Add sign-in success redirect and remove conflicting root redirect to fix silent sign-in failure.

The sign-in process on `/auth` was silently failing because there was no explicit redirect after a successful authentication. Additionally, a root `src/app/page.tsx` was unconditionally redirecting all traffic to `/auth`, which prevented any navigation after a successful login, creating a perceived "silent failure" loop. This PR resolves both issues and adds visible error messages for failed attempts.

---
<a href="https://cursor.com/background-agent?bcId=bc-87a25f8b-30e6-4f4c-87d5-10780d40bf98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87a25f8b-30e6-4f4c-87d5-10780d40bf98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

