### PR TITLE
Fix page rendering and fetch errors

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,12 +1,18 @@
 import { AuthProvider } from '@/hooks/useAuth'
-import Protected from './protected'
+import { createServerSupabase } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createServerSupabase()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    redirect('/auth')
+  }
   return (
     <AuthProvider>
-      <Protected>{children}</Protected>
+      {children}
     </AuthProvider>
   )
 }


### PR DESCRIPTION
Move authentication protection to the server-side layout to fix RSC flight fetch failures caused by client-side redirects.

The previous client-side `Protected` component could return an HTML redirect for unauthenticated users during an RSC flight fetch, which Next.js cannot parse as a valid RSC response, leading to a "Fetch failed loading" error. By performing the authentication check and redirect on the server in the layout, the response remains a proper RSC flight response, resolving the rendering issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-2aa72f46-2a97-461b-803b-6666cebf9b9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2aa72f46-2a97-461b-803b-6666cebf9b9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

