### PR TITLE
Fix overlapping navigation bar on desktop ui

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,9 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  /* Fallbacks to ensure desktop sidebar sizing always has sane defaults */
+  --sidebar-width: 16rem;
+  --sidebar-width-icon: 3rem;
 }
 
 @theme inline {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -230,6 +230,7 @@ const Sidebar = React.forwardRef<
               ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
           )}
+          style={{ width: "var(--sidebar-width, 16rem)" }}
         />
         <div
           className={cn(
@@ -243,6 +244,7 @@ const Sidebar = React.forwardRef<
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
             className
           )}
+          style={{ width: "var(--sidebar-width, 16rem)" }}
           {...props}
         >
           <div


### PR DESCRIPTION
Ensures the desktop left navigation bar maintains its width to prevent overlapping page content.

The previous change removed transparency from the sidebar, but the sidebar continued to overlap the main content area, making it unclickable. This PR fixes the issue by adding robust width definitions for the sidebar and its spacer, ensuring the content area is always correctly offset, even if CSS custom properties fail to cascade.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4a5dc98-7bc4-4063-ba97-5401f28f6e6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4a5dc98-7bc4-4063-ba97-5401f28f6e6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

