### PR TITLE
Fix employers not loading due to bad request

### DIFF
--- a/src/app/(app)/employers/page.tsx
+++ b/src/app/(app)/employers/page.tsx
@@ -37,8 +37,8 @@ export default function EmployersPage() {
         query = query.or([
           "estimated_worker_count.gt.0",
           "enterprise_agreement_status.eq.true",
-          "company_eba_records.id.not.is.null",
-          "worker_placements.id.not.is.null",
+          "id.in.(select employer_id from company_eba_records)",
+          "id.in.(select employer_id from worker_placements)",
         ].join(","))
       }
 


### PR DESCRIPTION
Fixes 400 Bad Request error in employer query by updating PostgREST filter syntax for related record existence.

---
<a href="https://cursor.com/background-agent?bcId=bc-3283244c-faca-49d2-8363-e28d4bba280c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3283244c-faca-49d2-8363-e28d4bba280c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

