### PR TITLE
Implement organizer role and patch system

### DIFF
--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -8,6 +8,10 @@ import { Button } from "@/components/ui/button"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import UsersTable from "@/components/admin/UsersTable"
 import RoleGuard from "@/components/guards/RoleGuard"
+import { useQuery } from "@tanstack/react-query"
+import { supabase } from "@/integrations/supabase/client"
+import { RoleHierarchyManager } from "@/components/admin/RoleHierarchyManager"
+import { OrganiserScopeManager } from "@/components/admin/OrganiserScopeManager"
 
 export default function AdminPage() {
   const [open, setOpen] = useState(false)
@@ -23,6 +27,8 @@ export default function AdminPage() {
           <TabsList>
             <TabsTrigger value="users">Users</TabsTrigger>
             <TabsTrigger value="invites">Invites</TabsTrigger>
+            <TabsTrigger value="hierarchy">Hierarchy</TabsTrigger>
+            <TabsTrigger value="scoping">Scoping</TabsTrigger>
           </TabsList>
           <TabsContent value="users">
             <UsersTable />
@@ -30,10 +36,31 @@ export default function AdminPage() {
           <TabsContent value="invites">
             <PendingUsersTable />
           </TabsContent>
+          <TabsContent value="hierarchy">
+            <AdminHierarchyTab />
+          </TabsContent>
+          <TabsContent value="scoping">
+            <OrganiserScopeManager />
+          </TabsContent>
         </Tabs>
         <InviteUserDialog open={open} onOpenChange={setOpen} onSuccess={() => {}} />
       </div>
     </RoleGuard>
   )
+}
+
+function AdminHierarchyTab() {
+  const { data: users = [] } = useQuery({
+    queryKey: ["admin-hierarchy-users"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("profiles")
+        .select("id, full_name, email, role")
+        .order("full_name")
+      if (error) throw error
+      return data || []
+    }
+  })
+  return <RoleHierarchyManager users={users as any} />
 }
 

--- a/src/components/admin/OrganiserScopeManager.tsx
+++ b/src/components/admin/OrganiserScopeManager.tsx
@@ -1,0 +1,152 @@
+"use client"
+import { useMemo, useState } from "react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { supabase } from "@/integrations/supabase/client"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import ScopeUserDialog from "@/components/admin/ScopeUserDialog"
+import { Badge } from "@/components/ui/badge"
+
+type UserRow = { id: string; full_name: string | null; email: string | null; role: string | null; scoped_sites?: string[] | null; scoped_employers?: string[] | null }
+
+export function OrganiserScopeManager() {
+  const qc = useQueryClient()
+  const [selectedUser, setSelectedUser] = useState<UserRow | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const { data: users = [] } = useQuery({
+    queryKey: ["organiser-scope-users"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("profiles")
+        .select("id, full_name, email, role, scoped_sites, scoped_employers")
+        .in("role", ["organiser", "lead_organiser"]) // scope managers only
+        .order("full_name")
+      if (error) throw error
+      return (data || []) as UserRow[]
+    }
+  })
+
+  const { data: employers = [] } = useQuery({
+    queryKey: ["organiser-scope-employers"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("employers")
+        .select("id, name")
+        .order("name")
+      if (error) throw error
+      return (data || []) as { id: string; name: string }[]
+    }
+  })
+
+  const { data: jobSites = [] } = useQuery({
+    queryKey: ["organiser-scope-sites"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("job_sites")
+        .select("id, name, location, project_id")
+        .order("name")
+      if (error) throw error
+      return (data || []) as { id: string; name: string; location?: string; project_id?: string }[]
+    }
+  })
+
+  const { data: projects = [] } = useQuery({
+    queryKey: ["organiser-scope-projects"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("projects")
+        .select("id, name")
+        .order("name")
+      if (error) throw error
+      return (data || []) as { id: string; name: string }[]
+    }
+  })
+
+  const projectSitesMap = useMemo(() => {
+    const map: Record<string, { id: string; name: string }[]> = {}
+    ;(jobSites as any[]).forEach((s: any) => {
+      const pid = s.project_id || ""
+      if (!pid) return
+      if (!map[pid]) map[pid] = []
+      map[pid].push({ id: s.id, name: s.name })
+    })
+    return map
+  }, [jobSites])
+
+  const updateScope = useMutation({
+    mutationFn: async ({ userId, scopedSites, scopedEmployers }: { userId: string; scopedSites: string[]; scopedEmployers: string[] }) => {
+      const { error } = await (supabase as any)
+        .from("profiles")
+        .update({ scoped_sites: scopedSites, scoped_employers: scopedEmployers })
+        .eq("id", userId)
+      if (error) throw error
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["organiser-scope-users"] })
+    }
+  })
+
+  const openDialog = (user: UserRow) => {
+    setSelectedUser(user)
+    setDialogOpen(true)
+  }
+
+  const displayName = (u: UserRow) => u.full_name || u.email || u.id
+
+  const organisers = useMemo(() => (users as UserRow[]).filter(u => u.role === "organiser" || u.role === "lead_organiser"), [users])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Organiser Scoping</CardTitle>
+        <CardDescription>Assign organisers to projects, job sites, and employers by scoping their access. This drives what appears in their patch.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-md border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Organiser</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Sites</TableHead>
+                <TableHead>Employers</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {organisers.map(u => (
+                <TableRow key={u.id}>
+                  <TableCell>{displayName(u)}</TableCell>
+                  <TableCell><Badge variant="secondary">{u.role}</Badge></TableCell>
+                  <TableCell>{u.scoped_sites?.length || 0}</TableCell>
+                  <TableCell>{u.scoped_employers?.length || 0}</TableCell>
+                  <TableCell className="text-right">
+                    <Button size="sm" variant="outline" onClick={() => openDialog(u)}>Edit scope</Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {selectedUser && (
+          <ScopeUserDialog
+            open={dialogOpen}
+            onOpenChange={setDialogOpen}
+            user={selectedUser as any}
+            employers={employers}
+            jobSites={jobSites as any}
+            projects={projects as any}
+            projectSitesMap={projectSitesMap}
+            onSave={({ userId, scopedSites, scopedEmployers }) => updateScope.mutate({ userId, scopedSites, scopedEmployers })}
+          />
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default OrganiserScopeManager
+


### PR DESCRIPTION
Adds admin tools for managing organiser hierarchy and scoping organiser access to projects, job sites, and employers, which updates their 'patch' view.

This PR implements the requested administrator capabilities to allocate organisers to lead organisers and assign organisers to specific projects, job sites, and employers. The 'patch' dashboard automatically reflects these assignments by leveraging existing `profiles.scoped_sites` and `profiles.scoped_employers` fields, requiring no database schema changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6209b42-7eec-44b0-b031-1f25c1c5f426">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6209b42-7eec-44b0-b031-1f25c1c5f426">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

