### PR TITLE
Fix build type error and unused variables

### DIFF
--- a/src/components/patchwall/EmployerWorkerChart.tsx
+++ b/src/components/patchwall/EmployerWorkerChart.tsx
@@ -403,10 +403,15 @@ const roleBadge = (role: WorkerRoleLite) => (
             />
 
             <UnionRoleAssignmentModal
-              workerId={roleWorkerId}
               isOpen={showRole}
               onClose={() => setShowRole(false)}
-              onAssigned={() => qc.invalidateQueries({ queryKey: ["employer-worker-chart"] })}
+              employerId={employerId!}
+              workers={filteredSortedWorkers.map((w) => ({
+                id: w.id,
+                first_name: w.first_name ?? "",
+                surname: w.surname ?? "",
+              }))}
+              onSuccess={() => qc.invalidateQueries({ queryKey: ["employer-worker-chart"] })}
             />
 
             <AssignWorkersModal


### PR DESCRIPTION
Corrects props passed to `UnionRoleAssignmentModal` to resolve a build-breaking type error.

---
<a href="https://cursor.com/background-agent?bcId=bc-a85e26b0-d505-4c18-9f0f-2ad025b8b195">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a85e26b0-d505-4c18-9f0f-2ad025b8b195">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

