### PR TITLE
Fix build error and eslint warnings

### DIFF
--- a/src/components/patchwall/EmployerWorkerChart.tsx
+++ b/src/components/patchwall/EmployerWorkerChart.tsx
@@ -415,11 +415,13 @@ const roleBadge = (role: WorkerRoleLite) => (
             />
 
             <AssignWorkersModal
-              isOpen={showAssign}
-              onClose={() => setShowAssign(false)}
-              employerId={employerId}
+              open={showAssign}
+              onOpenChange={setShowAssign}
+              employerId={employerId!}
+              employerName={employerName}
+              projectId={null}
               siteOptions={siteOptions}
-              defaultSiteId={contextSiteId || undefined}
+              defaultSiteId={contextSiteId ?? null}
               onAssigned={() => qc.invalidateQueries({ queryKey: ["employer-worker-chart"] })}
             />
           </>


### PR DESCRIPTION
Aligns `AssignWorkersModal` props in `EmployerWorkerChart` to fix a TypeScript build error.

The `AssignWorkersModal` component's prop types were updated in a previous commit (e.g., `open`/`onOpenChange` instead of `isOpen`/`onClose`, and `employerId` requiring `string` instead of `string | null`). This PR updates the call site in `EmployerWorkerChart.tsx` to match the new prop signature and type requirements, resolving the build failure. Previous attempts to fix the build did not address this specific component's prop mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-3abfb51b-839e-4aa5-9bbd-e98c926a88ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3abfb51b-839e-4aa5-9bbd-e98c926a88ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

