### PR TITLE
Fix auth refresh token deployment error

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -10,7 +10,13 @@ export const dynamic = 'force-dynamic'
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createServerSupabase()
-  const { data: { user } } = await supabase.auth.getUser()
+  let user = null as null | { id: string }
+  try {
+    const { data } = await supabase.auth.getUser()
+    user = data.user
+  } catch (err) {
+    // Ignore and treat as unauthenticated
+  }
   if (!user) {
     redirect('/auth')
   }

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -11,7 +11,10 @@ export function getSupabaseBrowserClient(): SupabaseClient<GenericDatabase> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   if (!url || !key) {
-    // Defer actual network usage until runtime; create a client with empty strings to avoid build-time throws.
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY')
+    }
+    // Dev-only fallback
     browserClient = createBrowserClient('http://localhost', 'public-anon-key')
     return browserClient
   }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -3,8 +3,35 @@ import { createServerClient, type CookieOptions } from '@supabase/ssr'
 
 export async function createServerSupabase() {
   const cookieStore = await cookies()
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost'
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'public-anon-key'
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!url || !key) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('Missing Supabase environment variables. Please set SUPABASE_URL and SUPABASE_ANON_KEY (or NEXT_PUBLIC_* equivalents).')
+    }
+    // Development fallback only
+    return createServerClient(
+      'http://localhost',
+      'public-anon-key',
+      {
+        cookies: {
+          get(name: string) {
+            return cookieStore.get(name)?.value
+          },
+          set(name: string, value: string, options: CookieOptions) {
+            try {
+              cookieStore.set({ name, value, ...options, path: '/' })
+            } catch {}
+          },
+          remove(name: string, options: CookieOptions) {
+            try {
+              cookieStore.set({ name, value: '', ...options, path: '/' })
+            } catch {}
+          },
+        },
+      }
+    )
+  }
   return createServerClient(
     url,
     key,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next()
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseAnonKey) return res
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      get(name: string) {
+        return req.cookies.get(name)?.value
+      },
+      set(name: string, value: string, options) {
+        try {
+          res.cookies.set({ name, value, ...options, path: '/' })
+        } catch {}
+      },
+      remove(name: string, options) {
+        try {
+          res.cookies.set({ name, value: '', ...options, path: '/' })
+        } catch {}
+      },
+    },
+  })
+
+  // Touch the session to allow refresh token rotation to set cookies server-side
+  try {
+    await supabase.auth.getSession()
+  } catch {}
+
+  return res
+}
+
+export const config = {
+  matcher: [
+    // apply on all app routes except static assets and api auth callback
+    '/((?!_next/|.*\.(?:css|js|map|png|jpg|jpeg|gif|svg|ico|woff2?)$|api/).*)',
+  ],
+}
+


### PR DESCRIPTION
Fix 'Invalid Refresh Token' errors by adding a Next.js middleware to persist Supabase refresh token rotations and hardening environment variable checks.

The "Invalid Refresh Token: Refresh Token Not Found" error was occurring because Supabase's refresh token rotation, when triggered server-side (e.g., during SSR), was unable to persist the new cookies. This PR introduces a Next.js middleware that initializes the Supabase server client with a cookie adapter, allowing rotated refresh tokens to be set in the response cookies, resolving the issue. It also improves environment variable validation for Supabase keys.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6573ec1-74a8-47db-821a-4de4acc0dba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6573ec1-74a8-47db-821a-4de4acc0dba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

