### PR TITLE
Change favicon to eureka stockade flag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,10 @@ export const metadata: Metadata = {
   title: "CFMEU App",
   description: "Next.js App Router migrated from Vite",
   icons: {
-    icon: "/icon.svg",
+    icon: [
+      { url: "/icon.svg", type: "image/svg+xml" },
+    ],
+    apple: "/icon.svg",
   },
 };
 


### PR DESCRIPTION
Set favicon to the Eureka Stockade flag by updating `layout.tsx` and removing conflicting `.ico` files.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea0aacc5-7ae1-46fe-8b4c-994f7dd1e892">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea0aacc5-7ae1-46fe-8b4c-994f7dd1e892">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

