### PR TITLE
Update and organize patch data

### DIFF
--- a/src/app/(app)/upload/page.tsx
+++ b/src/app/(app)/upload/page.tsx
@@ -11,6 +11,7 @@ import WorkerImport from "@/components/upload/WorkerImport"
 import ContractorImport from "@/components/upload/ContractorImport"
 import { EbaImport } from "@/components/upload/EbaImport"
 import { Button } from "@/components/ui/button"
+import PatchImport from "@/components/upload/PatchImport"
 import { ArrowLeft } from "lucide-react"
 
 export default function UploadPage() {
@@ -20,7 +21,7 @@ export default function UploadPage() {
 
   type ParsedCSV = { headers: string[]; rows: Record<string, any>[]; filename?: string }
   const [step, setStep] = useState<"choose" | "upload" | "map" | "import">("choose")
-  const [importType, setImportType] = useState<"workers" | "contractors" | "eba">("workers")
+  const [importType, setImportType] = useState<"workers" | "contractors" | "eba" | "patches">("workers")
   const [csv, setCsv] = useState<ParsedCSV | null>(null)
   const [mappedRows, setMappedRows] = useState<Record<string, any>[]>([])
 
@@ -34,7 +35,7 @@ export default function UploadPage() {
     setStep("map")
   }
 
-  const onMappingComplete = (_table: string, mappings: any[]) => {
+  const onMappingComplete = (table: string, mappings: any[]) => {
     if (!csv) return
     // Simple projection using mapped columns
     const output = csv.rows.map((row) => {
@@ -76,6 +77,7 @@ export default function UploadPage() {
                 <TabsTrigger value="workers">Workers</TabsTrigger>
                 <TabsTrigger value="contractors">Contractors</TabsTrigger>
                 <TabsTrigger value="eba">EBA</TabsTrigger>
+                <TabsTrigger value="patches">Patches</TabsTrigger>
               </TabsList>
               <TabsContent value="workers">
                 <FileUpload onFileUploaded={onFileUploaded} />
@@ -84,6 +86,9 @@ export default function UploadPage() {
                 <FileUpload onFileUploaded={onFileUploaded} />
               </TabsContent>
               <TabsContent value="eba">
+                <FileUpload onFileUploaded={onFileUploaded} />
+              </TabsContent>
+              <TabsContent value="patches">
                 <FileUpload onFileUploaded={onFileUploaded} />
               </TabsContent>
             </Tabs>
@@ -122,6 +127,13 @@ export default function UploadPage() {
             )}
             {importType === "eba" && (
               <EbaImport
+                csvData={mappedRows.length > 0 ? mappedRows : csv.rows}
+                onImportComplete={() => setStep("choose")}
+                onBack={() => setStep("map")}
+              />
+            )}
+            {importType === "patches" && (
+              <PatchImport
                 csvData={mappedRows.length > 0 ? mappedRows : csv.rows}
                 onImportComplete={() => setStep("choose")}
                 onBack={() => setStep("map")}

--- a/src/components/admin/PatchManager.tsx
+++ b/src/components/admin/PatchManager.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/components/ui/input"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { useToast } from "@/hooks/use-toast"
 
-type Patch = { id: string; name: string; type: string; status: string }
+type Patch = { id: string; name: string; type: string; status: string; code?: number | null; description?: string | null; sub_sectors?: string[] | null }
 
 export default function PatchManager() {
   const qc = useQueryClient()
@@ -24,7 +24,7 @@ export default function PatchManager() {
     queryFn: async () => {
       const { data, error } = await (supabase as any)
         .from("patches")
-        .select("id,name,type,status")
+        .select("id,name,type,status,code,description,sub_sectors")
         .order("name")
       if (error) throw error
       return (data || []) as Patch[]
@@ -69,6 +69,8 @@ export default function PatchManager() {
                 <TableHead>Name</TableHead>
                 <TableHead>Type</TableHead>
                 <TableHead>Status</TableHead>
+                <TableHead>Code</TableHead>
+                <TableHead>Sub-sectors</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -77,6 +79,8 @@ export default function PatchManager() {
                   <TableCell className="font-medium">{p.name}</TableCell>
                   <TableCell>{p.type}</TableCell>
                   <TableCell>{p.status}</TableCell>
+                  <TableCell>{(p as any).code ?? '—'}</TableCell>
+                  <TableCell>{((p as any).sub_sectors || []).length || 0}</TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -115,4 +119,3 @@ export default function PatchManager() {
     </Card>
   )
 }
-

--- a/src/components/upload/ColumnMapper.tsx
+++ b/src/components/upload/ColumnMapper.tsx
@@ -30,6 +30,21 @@ interface ColumnMapperProps {
 
 // Database schema for mapping
 const DATABASE_TABLES = {
+  patches: {
+    label: "Patches",
+    columns: {
+      code: { type: "number", required: false, description: "Numeric patch code (e.g., 100)" },
+      name: { type: "text", required: true, description: "Patch name (e.g., Sydney)" },
+      type: { type: "text", required: false, description: "Patch type: geo or trade (optional; inferred if blank)" },
+      description: { type: "text", required: false, description: "Patch description" },
+      organiser1: { type: "text", required: false, description: "Organiser 1 (full name or email)" },
+      organiser2: { type: "text", required: false, description: "Organiser 2 (full name or email)" },
+      sub_sector_1: { type: "text", required: false, description: "Sub-sector 1 (for trade patches)" },
+      sub_sector_2: { type: "text", required: false, description: "Sub-sector 2" },
+      sub_sector_3: { type: "text", required: false, description: "Sub-sector 3" },
+      sub_sector_4: { type: "text", required: false, description: "Sub-sector 4" },
+    }
+  },
   workers: {
     label: "Workers",
     columns: {

--- a/src/components/upload/DataPreview.tsx
+++ b/src/components/upload/DataPreview.tsx
@@ -250,25 +250,38 @@ const DataPreview = ({
 
   // Handle EBA tracking imports differently
   console.log('DataPreview: selectedTable =', selectedTable);
-  if (selectedTable === 'company_eba_records') {
+  if (selectedTable === 'company_eba_records' || selectedTable === 'patches') {
     return (
-      <EbaImport
-        csvData={parsedCSV.rows}
-        onImportComplete={(results) => {
-          onValidationComplete({
-            isValid: true,
-            errors: [],
-            warnings: results.errors.map(error => ({
-              row: 0,
-              column: '',
-              message: error,
-              value: ''
-            }))
-          });
-          onImportStart();
-        }}
-        onBack={onBack}
-      />
+      selectedTable === 'company_eba_records' ? (
+        <EbaImport
+          csvData={parsedCSV.rows}
+          onImportComplete={(results) => {
+            onValidationComplete({
+              isValid: true,
+              errors: [],
+              warnings: results.errors.map(error => ({
+                row: 0,
+                column: '',
+                message: error,
+                value: ''
+              }))
+            });
+            onImportStart();
+          }}
+          onBack={onBack}
+        />
+      ) : (
+        // For patches we will use the dedicated importer in the next step of the wizard; just mark validation okay
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Patches mapping ready</CardTitle>
+            <CardDescription>Proceed to import to upsert patches and organiser links.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={onImportStart}>Continue</Button>
+          </CardContent>
+        </Card>
+      )
     );
   }
 

--- a/src/components/upload/PatchImport.tsx
+++ b/src/components/upload/PatchImport.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Upload, CheckCircle, AlertCircle, Users } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
+
+type ImportResults = {
+  created: number;
+  updated: number;
+  organiserLinks: number;
+  failed: number;
+  errors: string[];
+};
+
+interface PatchImportProps {
+  csvData: Record<string, any>[];
+  onImportComplete: (results: ImportResults) => void;
+  onBack: () => void;
+}
+
+// Helper to coerce to integer (or null)
+function toInt(value: any): number | null {
+  if (value === null || value === undefined) return null;
+  const n = parseInt(String(value).replace(/[^0-9-]/g, ""), 10);
+  return isNaN(n) ? null : n;
+}
+
+export default function PatchImport({ csvData, onImportComplete, onBack }: PatchImportProps) {
+  const [isImporting, setIsImporting] = useState(false);
+  const [preview, setPreview] = useState<any[]>([]);
+  const [organisers, setOrganisers] = useState<Array<{ id: string; full_name: string; email: string | null }>>([]);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase.from("profiles").select("id, full_name, email");
+      setOrganisers((data as any[]) || []);
+    };
+    load();
+  }, []);
+
+  // Normalize rows into a consistent structure for preview and import
+  const normalizedRows = useMemo(() => {
+    const lower = (s: any) => (s ? String(s).toLowerCase() : "");
+    const isTruthy = (v: any) => v !== undefined && v !== null && String(v).trim() !== "";
+    const rows = (csvData || []).map((r) => {
+      const code = toInt(r["code"] ?? r["Patch code"] ?? r["patch_code"] ?? r["patch code"]);
+      const name = r["name"] ?? r["Patch name"] ?? r["patch"] ?? r["Patch"] ?? r["Patch description"] ?? r["description"];
+      const description = r["description"] ?? r["Patch description"] ?? r["patch_description"];
+      const org1 = r["organiser1"] ?? r["organiser 1"] ?? r["Organiser 1"] ?? r["Organizer 1"];
+      const org2 = r["organiser2"] ?? r["organiser 2"] ?? r["Organiser 2"] ?? r["Organizer 2"];
+      // Collect any columns that look like sub-sector definitions
+      const subCols = Object.keys(r).filter((k) => /sub\s*-?\s*sector|subsector|sub_sector/i.test(k));
+      const subSectors = subCols
+        .map((k) => String(r[k]).trim())
+        .filter((v) => isTruthy(v));
+      const type = subSectors.length > 0 || /trade/.test(lower(description)) ? "trade" : "geo";
+      return { code, name: name ? String(name).trim() : null, description: description || null, organiser1: org1 || null, organiser2: org2 || null, subSectors, type };
+    });
+    return rows.filter((r) => r.code !== null || r.name);
+  }, [csvData]);
+
+  useEffect(() => {
+    setPreview(normalizedRows.slice(0, 10));
+  }, [normalizedRows]);
+
+  const findOrganiserId = (value: any): string | null => {
+    if (!value) return null;
+    const target = String(value).trim().toLowerCase();
+    const exact = organisers.find((o) => (o.full_name || "").toLowerCase() === target || (o.email || "").toLowerCase() === target);
+    if (exact) return exact.id;
+    // Loose contains match on name if no exact match
+    const loose = organisers.find((o) => (o.full_name || "").toLowerCase().includes(target));
+    return loose ? loose.id : null;
+  };
+
+  const upsertOrganiserLink = async (organiserId: string, patchId: string) => {
+    try {
+      await (supabase as any).rpc("upsert_organiser_patch", { p_org: organiserId, p_patch: patchId });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const importRows = async () => {
+    setIsImporting(true);
+    const results: ImportResults = { created: 0, updated: 0, organiserLinks: 0, failed: 0, errors: [] };
+
+    for (const row of normalizedRows) {
+      try {
+        // Resolve existing patch by code (preferred) or by case-insensitive name
+        let existing: any = null;
+        if (row.code !== null) {
+          const { data } = await supabase.from("patches").select("id, code").eq("code", row.code).maybeSingle();
+          existing = data || null;
+        }
+        if (!existing && row.name) {
+          const { data } = await supabase.from("patches").select("id, name").ilike("name", row.name).limit(1).maybeSingle();
+          existing = data || null;
+        }
+
+        let patchId: string;
+        if (existing) {
+          // Try full update first; if it fails due to unknown columns, retry with minimal fields
+          const tryUpdate = async (payload: any) => {
+            const res = await supabase.from("patches").update(payload).eq("id", existing.id).select("id").single();
+            return res;
+          };
+          let { data, error } = await tryUpdate({
+            name: row.name,
+            description: row.description,
+            type: row.type,
+            // @ts-ignore optional column
+            sub_sectors: row.subSectors.length > 0 ? row.subSectors : null,
+            // @ts-ignore optional column
+            code: row.code,
+          });
+          if (error && /column .* does not exist/i.test(error.message || "")) {
+            ({ data, error } = await tryUpdate({ name: row.name, description: row.description, type: row.type }));
+          }
+          if (error) throw error;
+          patchId = (data as any).id;
+          results.updated++;
+        } else {
+          const tryInsert = async (payload: any) => {
+            const res = await supabase.from("patches").insert(payload).select("id").single();
+            return res;
+          };
+          let { data, error } = await tryInsert({
+            name: row.name,
+            description: row.description,
+            type: row.type,
+            // @ts-ignore optional
+            sub_sectors: row.subSectors.length > 0 ? row.subSectors : null,
+            // @ts-ignore optional
+            code: row.code,
+          });
+          if (error && /column .* does not exist/i.test(error.message || "")) {
+            ({ data, error } = await tryInsert({ name: row.name, description: row.description, type: row.type }));
+          }
+          if (error) throw error;
+          patchId = (data as any).id;
+          results.created++;
+        }
+
+        // Link organisers
+        const org1Id = findOrganiserId(row.organiser1);
+        const org2Id = findOrganiserId(row.organiser2);
+        if (org1Id) {
+          const ok = await upsertOrganiserLink(org1Id, patchId);
+          if (ok) results.organiserLinks++;
+        }
+        if (org2Id && org2Id !== org1Id) {
+          const ok = await upsertOrganiserLink(org2Id, patchId);
+          if (ok) results.organiserLinks++;
+        }
+      } catch (e: any) {
+        results.failed++;
+        results.errors.push(e?.message || "Unknown error");
+      }
+    }
+
+    if (results.failed > 0) {
+      toast({ title: "Import completed with errors", description: `${results.created} created, ${results.updated} updated, ${results.organiserLinks} organiser links. ${results.failed} failed.`, variant: "destructive" });
+    } else {
+      toast({ title: "Patches imported", description: `${results.created} created, ${results.updated} updated, ${results.organiserLinks} organiser links.` });
+    }
+    onImportComplete(results);
+    setIsImporting(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Upload className="h-5 w-5" />
+            Patch Import
+          </CardTitle>
+          <CardDescription>
+            We will create or update patches by code or name, store descriptions and sub-sectors, and link up to two organisers per row.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {preview.length === 0 ? (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>No rows detected. Please check your CSV mapping.</AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
+                <div className="space-y-1">
+                  <div className="text-2xl font-bold">{csvData.length}</div>
+                  <div className="text-sm text-muted-foreground">Total Rows</div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-2xl font-bold text-green-600">{preview.filter((r) => r.type === "geo").length}</div>
+                  <div className="text-sm text-muted-foreground">Sample Geo</div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-2xl font-bold text-blue-600">{preview.filter((r) => r.type === "trade").length}</div>
+                  <div className="text-sm text-muted-foreground">Sample Trade</div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-2xl font-bold flex items-center justify-center gap-1">
+                    <Users className="h-5 w-5" />
+                    {preview.filter((r) => r.organiser1 || r.organiser2).length}
+                  </div>
+                  <div className="text-sm text-muted-foreground">Rows with organisers</div>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <h4 className="font-medium">Preview (first 10 rows)</h4>
+                <div className="grid grid-cols-1 gap-2">
+                  {preview.map((r, i) => (
+                    <div key={i} className="p-3 rounded border text-sm">
+                      <div className="flex items-center justify-between">
+                        <div className="font-medium">{r.code ?? "—"} — {r.name ?? "(no name)"}</div>
+                        <Badge variant="secondary">{r.type}</Badge>
+                      </div>
+                      {r.description && <div className="text-muted-foreground">{r.description}</div>}
+                      {r.subSectors?.length > 0 && (
+                        <div className="text-xs text-muted-foreground mt-1">Sub-sectors: {r.subSectors.join(", ")}</div>
+                      )}
+                      {(r.organiser1 || r.organiser2) && (
+                        <div className="text-xs text-muted-foreground mt-1">Organisers: {[r.organiser1, r.organiser2].filter(Boolean).join(", ")}</div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <Button variant="outline" onClick={onBack}>Back to Mapping</Button>
+                <Button onClick={importRows} disabled={isImporting} className="ml-auto">
+                  <CheckCircle className="h-4 w-4 mr-2" />
+                  {isImporting ? "Importing..." : `Import ${csvData.length} Patches`}
+                </Button>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
Add a UI for CSV import of patch data to enable bulk upload and management of patch metadata (code, description, sub-sectors) and their associated organisers.

---
<a href="https://cursor.com/background-agent?bcId=bc-24de8650-9544-46cb-b30c-3cc8176c3bcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24de8650-9544-46cb-b30c-3cc8176c3bcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

