### PR TITLE
Diagnose and fix build errors

### DIFF
--- a/src/components/upload/PatchImport.tsx
+++ b/src/components/upload/PatchImport.tsx
@@ -114,9 +114,7 @@ export default function PatchImport({ csvData, onImportComplete, onBack }: Patch
             name: row.name,
             description: row.description,
             type: row.type,
-            // @ts-ignore optional column
             sub_sectors: row.subSectors.length > 0 ? row.subSectors : null,
-            // @ts-ignore optional column
             code: row.code,
           });
           if (error && /column .* does not exist/i.test(error.message || "")) {
@@ -134,9 +132,7 @@ export default function PatchImport({ csvData, onImportComplete, onBack }: Patch
             name: row.name,
             description: row.description,
             type: row.type,
-            // @ts-ignore optional
             sub_sectors: row.subSectors.length > 0 ? row.subSectors : null,
-            // @ts-ignore optional
             code: row.code,
           });
           if (error && /column .* does not exist/i.test(error.message || "")) {


### PR DESCRIPTION
Remove unnecessary `@ts-ignore` comments in `PatchImport.tsx` to resolve ESLint build errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a0f4540-d442-453e-a167-4b11b533339d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a0f4540-d442-453e-a167-4b11b533339d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

