### PR TITLE
Fix safari favicon display

### DIFF
--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 180,
+  height: 180,
+};
+
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+        <defs>
+          <style>
+            {`.bg{fill:#0b2a5b}.cross{fill:#ffffff}.star{fill:#ffffff}`}
+          </style>
+          <g id="star8">
+            <polygon className="star" points="128,100 138,118 160,128 138,138 128,156 118,138 96,128 118,118"/>
+            <polygon className="star" points="128,92 146,110 164,128 146,146 128,164 110,146 92,128 110,110"/>
+          </g>
+        </defs>
+        <rect className="bg" x="0" y="0" width="256" height="256"/>
+        <rect className="cross" x="32" y="110" width="192" height="36" rx="6"/>
+        <rect className="cross" x="110" y="32" width="36" height="192" rx="6"/>
+        <use href="#star8" x="0" y="0" />
+        <g transform="translate(0,-88)"><use href="#star8"/></g>
+        <g transform="translate(0,88)"><use href="#star8"/></g>
+        <g transform="translate(-88,0)"><use href="#star8"/></g>
+        <g transform="translate(88,0)"><use href="#star8"/></g>
+      </svg>
+    ),
+    size
+  );
+}
+

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 32,
+  height: 32,
+};
+
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+        <defs>
+          <style>
+            {`.bg{fill:#0b2a5b}.cross{fill:#ffffff}.star{fill:#ffffff}`}
+          </style>
+          <g id="star8">
+            <polygon className="star" points="128,100 138,118 160,128 138,138 128,156 118,138 96,128 118,118"/>
+            <polygon className="star" points="128,92 146,110 164,128 146,146 128,164 110,146 92,128 110,110"/>
+          </g>
+        </defs>
+        <rect className="bg" x="0" y="0" width="256" height="256"/>
+        <rect className="cross" x="32" y="110" width="192" height="36" rx="6"/>
+        <rect className="cross" x="110" y="32" width="36" height="192" rx="6"/>
+        <use href="#star8" x="0" y="0" />
+        <g transform="translate(0,-88)"><use href="#star8"/></g>
+        <g transform="translate(0,88)"><use href="#star8"/></g>
+        <g transform="translate(-88,0)"><use href="#star8"/></g>
+        <g transform="translate(88,0)"><use href="#star8"/></g>
+      </svg>
+    ),
+    size
+  );
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,13 @@ export const metadata: Metadata = {
   description: "Next.js App Router migrated from Vite",
   icons: {
     icon: [
-      { url: "/icon.svg", type: "image/svg+xml" },
+      { url: "/icon?v=2", type: "image/png" },
     ],
-    apple: "/icon.svg",
+    apple: "/apple-icon?v=2",
+    shortcut: "/icon?v=2",
+    other: [
+      { rel: "mask-icon", url: "/icon.svg?v=2" },
+    ],
   },
 };
 


### PR DESCRIPTION
Ensures the Eureka flag icon displays correctly in Safari by providing Safari-compatible PNG favicons and updating metadata to prevent caching issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b88ae1f-fd49-4bcf-b465-99c94bfcf1f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b88ae1f-fd49-4bcf-b465-99c94bfcf1f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

