### PR TITLE
Remove wallchart color key

### DIFF
--- a/src/components/patchwall/EmployerWorkerChart.tsx
+++ b/src/components/patchwall/EmployerWorkerChart.tsx
@@ -6,14 +6,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Card } from "@/components/ui/card";
-import { Loader2, MoreVertical, X, Info } from "lucide-react";
+import { Loader2, MoreVertical } from "lucide-react";
 import { toast } from "sonner";
 import { WorkerDetailModal } from "@/components/workers/WorkerDetailModal";
 import { UnionRoleAssignmentModal } from "@/components/workers/UnionRoleAssignmentModal";
 import { AssignWorkersModal } from "./AssignWorkersModal";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { getWorkerColorCoding, getWorkerColorLegend } from "@/utils/workerColorCoding";
-import { cn } from "@/lib/utils";
+import { getWorkerColorCoding } from "@/utils/workerColorCoding";
 
 interface EmployerWorkerChartProps {
   isOpen: boolean;
@@ -343,21 +342,7 @@ const roleBadge = (role: WorkerRoleLite) => (
         ) : data && data.workers.length > 0 ? (
 
           <>
-            {/* Colour Legend */}
-            <div className="mb-4 p-3 bg-muted/50 rounded-lg border">
-              <div className="flex items-center gap-2 mb-2">
-                <Info className="h-4 w-4 text-muted-foreground" />
-                <span className="text-sm font-medium">Colour Coding</span>
-              </div>
-              <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 text-xs">
-                {getWorkerColorLegend().map((item) => (
-                  <div key={item.label} className="flex items-center gap-1">
-                    <div className={cn("w-3 h-3 rounded border", item.color)} style={item.style} />
-                    <span className="text-muted-foreground">{item.description}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
+            
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {filteredSortedWorkers.map((w) => {


### PR DESCRIPTION
Remove the colour coding key from wallcharts as it was inaccurate and unnecessary.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1927f2a-0a04-498d-8f50-c8d3f5a50840">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1927f2a-0a04-498d-8f50-c8d3f5a50840">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

