### PR TITLE
Add patch upload and organizer management

### DIFF
--- a/src/components/admin/PatchManager.tsx
+++ b/src/components/admin/PatchManager.tsx
@@ -1,3 +1,11 @@
+import FileUpload from "@/components/upload/FileUpload"
+import ColumnMapper from "@/components/upload/ColumnMapper"
+import PatchImport from "@/components/upload/PatchImport"
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Separator } from "@/components/ui/separator"
+import { Plus } from "lucide-react"
+import { AddDraftUserDialog } from "@/components/admin/AddDraftUserDialog"
 "use client"
 import { useMemo, useState } from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
@@ -11,6 +19,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { useToast } from "@/hooks/use-toast"
 
 type Patch = { id: string; name: string; type: string; status: string; code?: number | null; description?: string | null; sub_sectors?: string[] | null }
+type ProfileUser = { id: string; full_name: string | null; email: string | null; role: string | null; is_active: boolean | null }
+type PendingUser = { id: string; email: string; full_name: string | null; role: string; status: string; assigned_patch_ids?: string[] | null }
 
 export default function PatchManager() {
   const qc = useQueryClient()
@@ -18,6 +28,12 @@ export default function PatchManager() {
   const [createOpen, setCreateOpen] = useState(false)
   const [name, setName] = useState("")
   const [type, setType] = useState<"geo" | "trade">("geo")
+  const [importOpen, setImportOpen] = useState(false)
+  const [importStep, setImportStep] = useState<"upload" | "map" | "import">("upload")
+  const [csv, setCsv] = useState<{ headers: string[]; rows: Record<string, any>[]; filename?: string } | null>(null)
+  const [mappedRows, setMappedRows] = useState<Record<string, any>[]>([])
+  const [assignDialogPatchId, setAssignDialogPatchId] = useState<string | null>(null)
+  const [draftDialogOpen, setDraftDialogOpen] = useState(false)
 
   const { data: patches = [], isLoading } = useQuery({
     queryKey: ["admin-patches"],
@@ -28,6 +44,50 @@ export default function PatchManager() {
         .order("name")
       if (error) throw error
       return (data || []) as Patch[]
+    }
+  })
+
+  const { data: organisers = [] } = useQuery({
+    queryKey: ["admin-patch-organisers"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("profiles")
+        .select("id, full_name, email, role, is_active")
+        .in("role", ["organiser", "lead_organiser"]) 
+        .order("full_name")
+      if (error) throw error
+      return (data || []) as ProfileUser[]
+    }
+  })
+
+  const { data: pendingOrganisers = [], refetch: refetchPending } = useQuery({
+    queryKey: ["admin-patch-pending-organisers"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("pending_users")
+        .select("id,email,full_name,role,status,assigned_patch_ids")
+        .eq("role", "organiser")
+        .in("status", ["draft", "invited"]) 
+        .order("created_at", { ascending: false })
+      if (error) throw error
+      return (data || []) as PendingUser[]
+    }
+  })
+
+  const { data: assignmentsByPatch = {} } = useQuery({
+    queryKey: ["admin-patch-assignments"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("organiser_patch_assignments")
+        .select("organiser_id, patch_id, effective_to")
+        .is("effective_to", null)
+      if (error) throw error
+      const map: Record<string, string[]> = {}
+      ;(data as any[]).forEach((row: any) => {
+        if (!map[row.patch_id]) map[row.patch_id] = []
+        map[row.patch_id].push(row.organiser_id)
+      })
+      return map
     }
   })
 
@@ -51,6 +111,69 @@ export default function PatchManager() {
     onError: (e: any) => toast({ title: "Error", description: e?.message || "Failed to create patch", variant: "destructive" })
   })
 
+  const assignToOrganiser = useMutation({
+    mutationFn: async ({ organiserId, patchId, assigned }: { organiserId: string; patchId: string; assigned: boolean }) => {
+      if (assigned) {
+        await (supabase as any).rpc("upsert_organiser_patch", { p_org: organiserId, p_patch: patchId })
+      } else {
+        await (supabase as any).rpc("close_organiser_patch", { p_org: organiserId, p_patch: patchId })
+      }
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin-patch-assignments"] })
+      toast({ title: "Assignments updated" })
+    },
+    onError: (e) => toast({ title: "Failed to update", description: (e as any)?.message || String(e), variant: "destructive" })
+  })
+
+  const updatePendingAllocations = useMutation({
+    mutationFn: async ({ pendingId, patchId, add }: { pendingId: string; patchId: string; add: boolean }) => {
+      const pending = (pendingOrganisers as PendingUser[]).find(p => p.id === pendingId)
+      const current = new Set<string>(pending?.assigned_patch_ids || [])
+      if (add) current.add(patchId); else current.delete(patchId)
+      const next = Array.from(current)
+      const { error } = await (supabase as any)
+        .from("pending_users")
+        .update({ assigned_patch_ids: next })
+        .eq("id", pendingId)
+      if (error) throw error
+    },
+    onSuccess: () => {
+      refetchPending()
+      toast({ title: "Draft allocations updated" })
+    },
+    onError: (e) => toast({ title: "Failed to update draft", description: (e as any)?.message || String(e), variant: "destructive" })
+  })
+
+  const openAssignDialog = (patchId: string) => setAssignDialogPatchId(patchId)
+  const closeAssignDialog = () => setAssignDialogPatchId(null)
+
+  const onFileUploaded = (parsed: { headers: string[]; rows: Record<string, any>[]; filename?: string }) => {
+    setCsv(parsed)
+    setImportStep("map")
+  }
+
+  const onMappingComplete = (_table: string, mappings: any[]) => {
+    if (!csv) return
+    const output = csv.rows.map((row) => {
+      const out: Record<string, any> = {}
+      mappings.forEach((m: any) => {
+        if (m.action !== 'skip' && m.dbColumn) {
+          out[m.dbColumn] = row[m.csvColumn]
+        }
+      })
+      return out
+    })
+    setMappedRows(output)
+    setImportStep("import")
+  }
+
+  const resetImport = () => {
+    setImportStep("upload")
+    setCsv(null)
+    setMappedRows([])
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -60,7 +183,10 @@ export default function PatchManager() {
       <CardContent className="space-y-3">
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground">{isLoading ? "Loading…" : `${(patches as any[]).length} patches`}</div>
-          <Button onClick={() => setCreateOpen(true)}>Create Patch</Button>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={() => setImportOpen(true)}>Import CSV</Button>
+            <Button onClick={() => setCreateOpen(true)}>Create Patch</Button>
+          </div>
         </div>
         <div className="rounded-md border overflow-x-auto">
           <Table>
@@ -71,6 +197,8 @@ export default function PatchManager() {
                 <TableHead>Status</TableHead>
                 <TableHead>Code</TableHead>
                 <TableHead>Sub-sectors</TableHead>
+                <TableHead>Organisers</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -81,6 +209,26 @@ export default function PatchManager() {
                   <TableCell>{p.status}</TableCell>
                   <TableCell>{(p as any).code ?? '—'}</TableCell>
                   <TableCell>{((p as any).sub_sectors || []).length || 0}</TableCell>
+                  <TableCell className="max-w-[280px]">
+                    <div className="flex flex-wrap gap-1">
+                      {(assignmentsByPatch as Record<string, string[]>)[p.id]?.map(orgId => {
+                        const user = (organisers as ProfileUser[]).find(u => u.id === orgId)
+                        const label = user?.full_name || user?.email || orgId
+                        return (
+                          <Badge key={orgId} variant="secondary">{label}</Badge>
+                        )
+                      }) || null}
+                      {(pendingOrganisers as PendingUser[]).filter(po => (po.assigned_patch_ids || []).includes(p.id)).map(po => (
+                        <Badge key={`pending-${po.id}`} variant="outline">{po.full_name || po.email} <span className="ml-1">(pending)</span></Badge>
+                      ))}
+                      {!(assignmentsByPatch as Record<string, string[]>)[p.id]?.length && !(pendingOrganisers as PendingUser[]).some(po => (po.assigned_patch_ids || []).includes(p.id)) && (
+                        <span className="text-sm text-muted-foreground">None</span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button size="sm" variant="outline" onClick={() => openAssignDialog(p.id)}>Manage</Button>
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -115,6 +263,126 @@ export default function PatchManager() {
             </div>
           </DialogContent>
         </Dialog>
+
+        <Dialog open={importOpen} onOpenChange={(o) => { setImportOpen(o); if (!o) resetImport() }}>
+          <DialogContent className="max-w-4xl">
+            <DialogHeader>
+              <DialogTitle>Import patches from CSV</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              {importStep === "upload" && (
+                <FileUpload onFileUploaded={onFileUploaded} />
+              )}
+              {importStep === "map" && csv && (
+                <ColumnMapper
+                  parsedCSV={csv}
+                  onBack={() => setImportStep("upload")}
+                  onMappingComplete={onMappingComplete}
+                />
+              )}
+              {importStep === "import" && csv && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Import Preview</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <PatchImport
+                      csvData={mappedRows.length > 0 ? mappedRows : (csv?.rows || [])}
+                      onImportComplete={() => { resetImport(); setImportOpen(false); qc.invalidateQueries({ queryKey: ["admin-patches"] }) }}
+                      onBack={() => setImportStep("map")}
+                    />
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog open={!!assignDialogPatchId} onOpenChange={(o) => { if (!o) closeAssignDialog() }}>
+          <DialogContent className="max-w-3xl">
+            <DialogHeader>
+              <DialogTitle>Manage organisers for this patch</DialogTitle>
+            </DialogHeader>
+            {assignDialogPatchId && (
+              <div className="space-y-6">
+                <div>
+                  <div className="text-sm font-medium mb-2">Active organisers</div>
+                  <div className="rounded border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Organiser</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead className="text-right">Assigned</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {(organisers as ProfileUser[]).map(u => {
+                          const assigned = Boolean((assignmentsByPatch as Record<string, string[]>)[assignDialogPatchId!]?.includes(u.id))
+                          return (
+                            <TableRow key={u.id}>
+                              <TableCell>{u.full_name || u.email || u.id}</TableCell>
+                              <TableCell>
+                                <Badge variant={u.is_active ? "default" : "secondary"}>{u.is_active ? "Active" : "Inactive"}</Badge>
+                              </TableCell>
+                              <TableCell className="text-right">
+                                <Checkbox
+                                  checked={assigned}
+                                  onCheckedChange={(v) => assignToOrganiser.mutate({ organiserId: u.id, patchId: assignDialogPatchId!, assigned: Boolean(v) })}
+                                />
+                              </TableCell>
+                            </TableRow>
+                          )
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="text-sm font-medium">Draft and invited organisers</div>
+                    <Button size="sm" onClick={() => setDraftDialogOpen(true)}><Plus className="h-4 w-4 mr-1" />Add draft organiser</Button>
+                  </div>
+                  <div className="rounded border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Organiser</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead className="text-right">Planned assignment</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {(pendingOrganisers as PendingUser[]).map(pu => {
+                          const planned = Boolean((pu.assigned_patch_ids || []).includes(assignDialogPatchId!))
+                          return (
+                            <TableRow key={pu.id}>
+                              <TableCell>{pu.full_name || pu.email}</TableCell>
+                              <TableCell>
+                                <Badge variant={pu.status === 'draft' ? 'secondary' : 'default'}>{pu.status === 'draft' ? 'Not-invited' : 'Pending'}</Badge>
+                              </TableCell>
+                              <TableCell className="text-right">
+                                <Checkbox
+                                  checked={planned}
+                                  onCheckedChange={(v) => updatePendingAllocations.mutate({ pendingId: pu.id, patchId: assignDialogPatchId!, add: Boolean(v) })}
+                                />
+                              </TableCell>
+                            </TableRow>
+                          )
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+
+        <AddDraftUserDialog open={draftDialogOpen} onOpenChange={(o) => { setDraftDialogOpen(o); if (!o) refetchPending() }} onSuccess={() => { refetchPending() }} />
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
Re-enables patch CSV upload and adds organiser management with pre-allocation and status indicators to the admin Patches tab.

---
<a href="https://cursor.com/background-agent?bcId=bc-a2786315-8689-4f58-a45a-72d917fdc701">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a2786315-8689-4f58-a45a-72d917fdc701">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

