### PR TITLE
Fix safari browser icon to eureka flag

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -20,4 +20,8 @@
   <g transform="translate(0,88)"><use href="#star8"/></g>
   <g transform="translate(-88,0)"><use href="#star8"/></g>
   <g transform="translate(88,0)"><use href="#star8"/></g>
+  <!-- Center star for Eureka Stockade -->
+  <g transform="translate(0,0)">
+    <polygon class="star" points="128,120 136,128 128,136 120,128"/>
+  </g>
 </svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,12 +18,12 @@ export const metadata: Metadata = {
   description: "Next.js App Router migrated from Vite",
   icons: {
     icon: [
-      { url: "/icon?v=2", type: "image/png" },
+      { url: "/icon", type: "image/png" },
     ],
-    apple: "/apple-icon?v=2",
-    shortcut: "/icon?v=2",
+    apple: "/apple-icon",
+    shortcut: "/icon",
     other: [
-      { rel: "mask-icon", url: "/icon.svg?v=2" },
+      { rel: "mask-icon", url: "/icon.svg", color: "#0b2a5b" },
     ],
   },
 };


### PR DESCRIPTION
Replace Safari and app icons with the Eureka flag to remove the reverted 'lovable' icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-46bf23a0-acd4-4715-b6e6-b7f95373afbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46bf23a0-acd4-4715-b6e6-b7f95373afbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

