### PR TITLE
Fix patch upload screen scrolling

### DIFF
--- a/src/components/upload/PatchImport.tsx
+++ b/src/components/upload/PatchImport.tsx
@@ -313,7 +313,7 @@ export default function PatchImport({ csvData, onImportComplete, onBack }: Patch
       </Card>
 
       <Dialog open={resolverOpen} onOpenChange={setResolverOpen}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Resolve organisers</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
Enable scrolling on the organiser match screen during patch CSV upload to allow users to access action buttons.

---
<a href="https://cursor.com/background-agent?bcId=bc-40605311-f08a-4feb-9f9a-3d939644797f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40605311-f08a-4feb-9f9a-3d939644797f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

