### PR TITLE
Changes from background agent bc-733b6105-2a50-4852-97cd-82758b41c178

### DIFF
--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -76,11 +76,15 @@ function useProjectStats(projectId: string) {
     staleTime: 30000,
     refetchOnWindowFocus: false,
     queryFn: async () => {
-      // Contractors via site_contractor_trades
-      const { data: sct } = await (supabase as any)
-        .from("site_contractor_trades")
-        .select("employer_id, job_site_id")
-        .in("job_site_id", siteIds.length > 0 ? siteIds : ["-"])
+      // Contractors via site_contractor_trades (skip query if there are no sites)
+      let sct: any[] = []
+      if (siteIds.length > 0) {
+        const { data } = await (supabase as any)
+          .from("site_contractor_trades")
+          .select("employer_id, job_site_id")
+          .in("job_site_id", siteIds)
+        sct = (data as any[]) || []
+      }
 
       const employerIds = Array.from(new Set(((sct || []).map((r: any) => r.employer_id).filter(Boolean)))) as string[]
 

--- a/src/components/context/FiltersBar.tsx
+++ b/src/components/context/FiltersBar.tsx
@@ -102,24 +102,28 @@ export function FiltersBar({ patchOptions, statusOptions }: FiltersBarProps) {
       }
 
       // Fallback legacy: derive from job_sites.patch; then optional projects.region
-      const { data: sites } = await (supabase as any)
-        .from("job_sites")
-        .select("id, patch")
-        .limit(2000)
       const set = new Set<string>()
-      ;(sites as any[] || []).forEach((s) => {
-        const val = (s as any).patch
-        if (typeof val === "string" && val.trim() !== "") set.add(val.trim())
-      })
-      if (set.size === 0) {
-        const { data: projects } = await (supabase as any)
-          .from("projects")
-          .select("id, region")
+      try {
+        const { data: sites } = await (supabase as any)
+          .from("job_sites")
+          .select("id, patch")
           .limit(2000)
-        ;(projects as any[] || []).forEach((p) => {
-          const val = (p as any).region
+        ;(sites as any[] || []).forEach((s) => {
+          const val = (s as any).patch
           if (typeof val === "string" && val.trim() !== "") set.add(val.trim())
         })
+      } catch {}
+      if (set.size === 0) {
+        try {
+          const { data: projects } = await (supabase as any)
+            .from("projects")
+            .select("id, region")
+            .limit(2000)
+          ;(projects as any[] || []).forEach((p) => {
+            const val = (p as any).region
+            if (typeof val === "string" && val.trim() !== "") set.add(val.trim())
+          })
+        } catch {}
       }
       return Array.from(set).sort().map((v) => ({ value: v, label: v.charAt(0).toUpperCase() + v.slice(1) }))
     }


### PR DESCRIPTION
Prevent 400 errors on the project page by improving Supabase query handling and adding error resilience.

The `site_contractor_trades` query was generating invalid `in.(-)` filters when no site IDs were present, causing 400 Bad Request errors. This change skips the query in such cases. Additionally, fallback data fetches for patch options (from `job_sites.patch` and `projects.region`) are now wrapped in `try/catch` to prevent console errors and ensure graceful degradation if these legacy fields or tables are missing in the Supabase schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-733b6105-2a50-4852-97cd-82758b41c178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-733b6105-2a50-4852-97cd-82758b41c178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

