### PR TITLE
Fix campaign creation select state error

### DIFF
--- a/src/app/(app)/campaigns/page.tsx
+++ b/src/app/(app)/campaigns/page.tsx
@@ -34,25 +34,28 @@ export default function CampaignsPage() {
   })
 
   const [name, setName] = useState("")
-  const [type, setType] = useState<'compliance_blitz' | 'general' | undefined>(undefined)
+  const [type, setType] = useState<'compliance_blitz' | 'general' | ''>('')
   const [start, setStart] = useState("")
   const [end, setEnd] = useState("")
 
   const createCampaign = useMutation({
     mutationFn: async () => {
       if (!name || !type || !start || !end) throw new Error("Fill all fields")
+      const { data: userData } = await supabase.auth.getUser()
+      const createdBy = userData.user?.id ?? null
       const { error } = await supabase.from("campaigns").insert({
         name,
         type,
         start_date: start,
         end_date: end,
-        status: 'planned'
+        status: 'planned',
+        created_by: createdBy,
       })
       if (error) throw error
     },
     onSuccess: async () => {
       setName("")
-      setType(undefined)
+      setType('')
       setStart("")
       setEnd("")
       await qc.invalidateQueries({ queryKey: ["campaigns-list"] })


### PR DESCRIPTION
Fixes campaign creation by making the Select component consistently controlled and including the `created_by` field in the insert payload.

The `Select` component was throwing a warning because its value switched from `undefined` (uncontrolled) to a string (controlled). The 400 error was due to a missing `created_by` field in the Supabase insert, which is likely required by database constraints or Row Level Security.

---
<a href="https://cursor.com/background-agent?bcId=bc-f837de2d-6801-40df-ab72-a20d1be05dee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f837de2d-6801-40df-ab72-a20d1be05dee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

