### PR TITLE
Add manual draft organiser creation and role assignment

### DIFF
--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic'
 
 import { PendingUsersTable } from "@/components/admin/PendingUsersTable"
 import { InviteUserDialog } from "@/components/admin/InviteUserDialog"
+import { AddDraftUserDialog } from "@/components/admin/AddDraftUserDialog"
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
@@ -16,6 +17,7 @@ import PatchManager from "@/components/admin/PatchManager"
 
 export default function AdminPage() {
   const [open, setOpen] = useState(false)
+  const [addDraftOpen, setAddDraftOpen] = useState(false)
 
   return (
     <RoleGuard allow={["admin"]}>
@@ -36,6 +38,10 @@ export default function AdminPage() {
             <UsersTable />
           </TabsContent>
           <TabsContent value="invites">
+            <div className="flex items-center justify-between mb-2">
+              <div />
+              <Button variant="outline" onClick={() => setAddDraftOpen(true)}>Add draft organiser</Button>
+            </div>
             <PendingUsersTable />
           </TabsContent>
           <TabsContent value="hierarchy">
@@ -49,6 +55,7 @@ export default function AdminPage() {
           </TabsContent>
         </Tabs>
         <InviteUserDialog open={open} onOpenChange={setOpen} onSuccess={() => {}} />
+        <AddDraftUserDialog open={addDraftOpen} onOpenChange={setAddDraftOpen} onSuccess={() => {}} />
       </div>
     </RoleGuard>
   )


### PR DESCRIPTION
Adds a manual 'Add draft organiser' option to the Administration/Invites page to allow administrators to create draft organiser records directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-652d4c79-66f8-4a10-b421-70cf718ba68f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-652d4c79-66f8-4a10-b421-70cf718ba68f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

