### PR TITLE
Fix build errors in PatchImport component

### DIFF
--- a/src/components/upload/PatchImport.tsx
+++ b/src/components/upload/PatchImport.tsx
@@ -1,13 +1,13 @@
 import { useState, useEffect, useMemo } from "react";
-import { useSupabase } from "@/hooks/useSupabase";
+import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
-import { Alert, AlertDescription, AlertCircle } from "@/components/ui/alert";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
-import { CheckCircle, Upload, Users } from "lucide-react";
+import { AlertCircle, CheckCircle, Upload, Users } from "lucide-react";
 import { Input } from "@/components/ui/input";
 
 


### PR DESCRIPTION
Corrects `useSupabase` and `AlertCircle` imports in `PatchImport.tsx` to resolve build failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a66ea70-7dbe-4d76-af2a-6d7482e886b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a66ea70-7dbe-4d76-af2a-6d7482e886b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

