### PR TITLE
Investigate and fix draft organizer save bug

### DIFF
--- a/src/components/admin/AddDraftUserDialog.tsx
+++ b/src/components/admin/AddDraftUserDialog.tsx
@@ -32,13 +32,14 @@ export const AddDraftUserDialog = ({ open, onOpenChange, onSuccess }: AddDraftUs
   }
 
   const handleAdd = async () => {
-    if (!email) {
+    const finalEmail = (email && email.trim()) || inferDefaultEmail(fullName)
+    if (!finalEmail) {
       toast({
         title: "Error",
-        description: "Please enter an email address",
+        description: "Please enter a name or email address",
         variant: "destructive",
-      });
-      return;
+      })
+      return
     }
 
     setLoading(true);
@@ -47,8 +48,8 @@ export const AddDraftUserDialog = ({ open, onOpenChange, onSuccess }: AddDraftUs
       const createdBy = me.user?.id ?? null;
 
       const { error } = await supabase.from("pending_users" as any).insert({
-        email: email || inferDefaultEmail(fullName),
-        full_name: fullName || (email ? email.split("@")[0] : ""),
+        email: finalEmail,
+        full_name: fullName || finalEmail.split("@")[0],
         role,
         notes: notes || null,
         status: "draft",
@@ -57,7 +58,7 @@ export const AddDraftUserDialog = ({ open, onOpenChange, onSuccess }: AddDraftUs
 
       if (error) throw error;
 
-      toast({ title: "Draft created", description: `Saved ${email} as a draft user.` });
+      toast({ title: "Draft created", description: `Saved ${finalEmail} as a draft user.` });
       setEmail("");
       setFullName("");
       setRole("viewer");


### PR DESCRIPTION
Allow draft organisers to be created with inferred emails, fixing a bug where they couldn't be saved without a manually entered email.

The recent CSV upload changes introduced auto-generation of default email addresses. However, the `AddDraftUserDialog` component still enforced a manual email entry, preventing draft organisers from being saved when only a name was provided. This change updates the dialog to accept and use the inferred email when the email field is left blank.

---
<a href="https://cursor.com/background-agent?bcId=bc-78f2cc5e-7407-4aba-99ca-d7783b44f648">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78f2cc5e-7407-4aba-99ca-d7783b44f648">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

