### PR TITLE
Replace lovable icon with eureka flag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,12 +18,13 @@ export const metadata: Metadata = {
   description: "Next.js App Router migrated from Vite",
   icons: {
     icon: [
-      { url: "/icon", type: "image/png" },
+      { url: "/icon?v=2", type: "image/png" },
+      { url: "/favicon.ico?v=2", type: "image/x-icon" },
     ],
-    apple: "/apple-icon",
-    shortcut: "/icon",
+    apple: "/apple-icon?v=2",
+    shortcut: "/icon?v=2",
     other: [
-      { rel: "mask-icon", url: "/icon.svg", color: "#0b2a5b" },
+      { rel: "mask-icon", url: "/icon.svg?v=2", color: "#0b2a5b" },
     ],
   },
 };


### PR DESCRIPTION
Forces the Eureka flag icon across all browsers by updating icon metadata with cache-busting parameters.

The previous "lovable" icon persisted due to aggressive browser caching. This PR ensures the Eureka flag icon is consistently displayed by explicitly setting it in `layout.tsx` and adding version query parameters to bypass caching. Conflicting favicon files were also removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-385e2877-ca4c-425e-84ad-20a256e97a1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-385e2877-ca4c-425e-84ad-20a256e97a1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

