### PR TITLE
Debug patch creation and import

### DIFF
--- a/src/components/admin/PatchManager.tsx
+++ b/src/components/admin/PatchManager.tsx
@@ -112,9 +112,11 @@ export default function PatchManager() {
   const createPatch = useMutation({
     mutationFn: async () => {
       if (!name.trim()) throw new Error("Enter a name")
+      const { data: auth } = await (supabase as any).auth.getUser()
+      const createdBy = (auth as any)?.user?.id ?? null
       const { error } = await (supabase as any)
         .from("patches")
-        .insert({ name: name.trim() })
+        .insert({ name: name.trim(), type: "geo", created_by: createdBy })
       if (error) throw error
     },
     onSuccess: () => {


### PR DESCRIPTION
Fix manual patch creation and harden CSV import to ensure `type` and `created_by` are set.

Manual patch creation was failing due to the `patches` table requiring a `type` column, which was not being provided. CSV import now skips rows without a name and provides clearer error messages for RLS violations.

---
<a href="https://cursor.com/background-agent?bcId=bc-220f703a-441d-42ca-b388-13d693f46351">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-220f703a-441d-42ca-b388-13d693f46351">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

