### PR TITLE
Update header and menu icons to favicon

### DIFF
--- a/src/components/DesktopLayout.tsx
+++ b/src/components/DesktopLayout.tsx
@@ -25,8 +25,8 @@ import { LogOut, Users, Building, FolderOpen, FileCheck, Shield, BarChart3 } fro
 import { FiltersBar } from "@/components/context/FiltersBar"
 import { supabase } from "@/integrations/supabase/client"
 
-const cfmeuLogoLight = "/icon.svg" as unknown as string
-const cfmeuLogoDark = "/icon.svg" as unknown as string
+const cfmeuLogoLight = "/favicon.svg" as unknown as string
+const cfmeuLogoDark = "/favicon.svg" as unknown as string
 
 type NavItem = { path: string; label: string; icon: any }
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,8 +10,8 @@ import { usePathname } from "next/navigation";
 import { supabase } from "@/integrations/supabase/client";
 import { FiltersBar } from "@/components/context/FiltersBar";
 // Fallback to generic icon from public since original assets are not present
-const cfmeuLogoLight = "/icon.svg" as unknown as string;
-const cfmeuLogoDark = "/icon.svg" as unknown as string;
+const cfmeuLogoLight = "/favicon.svg" as unknown as string;
+const cfmeuLogoDark = "/favicon.svg" as unknown as string;
 
 const navItems = [
   { path: "/projects", label: "Projects", icon: FolderOpen },


### PR DESCRIPTION
Replace page header and menu bar icons with `favicon.svg` to standardize the application's branding.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1aa8358-b482-4abd-a517-a63f2512a8ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1aa8358-b482-4abd-a517-a63f2512a8ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

