### PR TITLE
Update patch assignment for lead and draft organisers

### DIFF
--- a/src/components/admin/RoleHierarchyManager.tsx
+++ b/src/components/admin/RoleHierarchyManager.tsx
@@ -22,6 +22,12 @@ export const RoleHierarchyManager = ({ users }: RoleHierarchyManagerProps) => {
   const [draftPendingId, setDraftPendingId] = useState<string>("");
   const [draftLinks, setDraftLinks] = useState<Array<{ id: string; lead_user_id: string; pending_user_id: string }>>([]);
   const [pendingOrganisers, setPendingOrganisers] = useState<Array<{ id: string; email: string; full_name: string | null; status: string }>>([]);
+  // Draft Lead management
+  const [pendingLeads, setPendingLeads] = useState<Array<{ id: string; email: string; full_name: string | null; status: string }>>([]);
+  const [draftLeadPendingId, setDraftLeadPendingId] = useState<string>("");
+  const [draftLeadToOrganiserId, setDraftLeadToOrganiserId] = useState<string>("");
+  const [draftLeadToPendingId, setDraftLeadToPendingId] = useState<string>("");
+  const [draftLeadLinks, setDraftLeadLinks] = useState<Array<{ id: string; draft_lead_pending_user_id: string; organiser_user_id: string | null; organiser_pending_user_id: string | null }>>([]);
 
   const leads = useMemo(() => users.filter(u => u.role === "lead_organiser"), [users]);
   const organisers = useMemo(() => users.filter(u => u.role === "organiser"), [users]);
@@ -50,7 +56,12 @@ export const RoleHierarchyManager = ({ users }: RoleHierarchyManagerProps) => {
   useEffect(() => {
     const fetchDraftData = async () => {
       const today = new Date().toISOString().slice(0, 10);
-      const [{ data: pending, error: pErr }, { data: dl, error: dErr }] = await Promise.all([
+      const [
+        { data: pending, error: pErr },
+        { data: dl, error: dErr },
+        { data: pLeads, error: plErr },
+        { data: draftLeadRows, error: draftLeadErr }
+      ] = await Promise.all([
         supabase
           .from("pending_users")
           .select("id,email,full_name,status")
@@ -60,6 +71,18 @@ export const RoleHierarchyManager = ({ users }: RoleHierarchyManagerProps) => {
         supabase
           .from("lead_draft_organiser_links")
           .select("id,lead_user_id,pending_user_id")
+          .eq("is_active", true)
+          .or(`end_date.is.null,end_date.gte.${today}`)
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("pending_users")
+          .select("id,email,full_name,status")
+          .eq("role", "lead_organiser")
+          .in("status", ["draft", "invited"]) 
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("draft_lead_organiser_links")
+          .select("id,draft_lead_pending_user_id,organiser_user_id,organiser_pending_user_id")
           .eq("is_active", true)
           .or(`end_date.is.null,end_date.gte.${today}`)
           .order("created_at", { ascending: false })
@@ -75,6 +98,18 @@ export const RoleHierarchyManager = ({ users }: RoleHierarchyManagerProps) => {
         toast({ title: "Error", description: "Failed to load draft links", variant: "destructive" });
       } else {
         setDraftLinks(dl || []);
+      }
+      if (plErr) {
+        console.error(plErr);
+        toast({ title: "Error", description: "Failed to load draft leads", variant: "destructive" });
+      } else {
+        setPendingLeads(pLeads || []);
+      }
+      if (draftLeadErr) {
+        console.error(draftLeadErr);
+        toast({ title: "Error", description: "Failed to load draft lead links", variant: "destructive" });
+      } else {
+        setDraftLeadLinks(draftLeadRows || []);
       }
     };
     fetchDraftData();
@@ -181,6 +216,59 @@ export const RoleHierarchyManager = ({ users }: RoleHierarchyManagerProps) => {
   const pendingLabel = (id: string) => {
     const p = pendingOrganisers.find(x => x.id === id);
     return p?.full_name || p?.email || id;
+  };
+  const pendingLeadLabel = (id: string) => {
+    const p = pendingLeads.find(x => x.id === id);
+    return p?.full_name || p?.email || id;
+  };
+
+  const addDraftLeadLink = async () => {
+    if (!draftLeadPendingId || (!draftLeadToOrganiserId && !draftLeadToPendingId)) {
+      toast({ title: "Select draft lead and a target", description: "Choose a draft lead and an organiser (live or draft)" });
+      return;
+    }
+    setLoading(true);
+    try {
+      const { data: auth } = await supabase.auth.getUser();
+      const assignedBy = (auth as any)?.user?.id ?? null;
+      const payload: any = { draft_lead_pending_user_id: draftLeadPendingId, assigned_by: assignedBy };
+      if (draftLeadToOrganiserId) payload.organiser_user_id = draftLeadToOrganiserId;
+      if (draftLeadToPendingId) payload.organiser_pending_user_id = draftLeadToPendingId;
+      const { error } = await supabase.from("draft_lead_organiser_links").insert(payload);
+      if (error) throw error;
+      toast({ title: "Draft lead linked", description: "Draft lead linked to organiser" });
+      setDraftLeadPendingId("");
+      setDraftLeadToOrganiserId("");
+      setDraftLeadToPendingId("");
+      const today = new Date().toISOString().slice(0, 10);
+      const { data } = await supabase
+        .from("draft_lead_organiser_links")
+        .select("id,draft_lead_pending_user_id,organiser_user_id,organiser_pending_user_id")
+        .eq("is_active", true)
+        .or(`end_date.is.null,end_date.gte.${today}`)
+        .order("created_at", { ascending: false });
+      setDraftLeadLinks(data || []);
+    } catch (e: any) {
+      console.error(e);
+      toast({ title: "Error", description: e.message || "Failed to create draft lead link", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const removeDraftLeadLink = async (id: string) => {
+    setLoading(true);
+    try {
+      const { error } = await supabase.from("draft_lead_organiser_links").update({ is_active: false, end_date: new Date().toISOString().slice(0, 10) }).eq("id", id);
+      if (error) throw error;
+      setDraftLeadLinks(prev => prev.filter(l => l.id !== id));
+      toast({ title: "Removed", description: "Draft lead link removed" });
+    } catch (e: any) {
+      console.error(e);
+      toast({ title: "Error", description: e.message || "Failed to remove draft lead link", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -308,6 +396,85 @@ export const RoleHierarchyManager = ({ users }: RoleHierarchyManagerProps) => {
                     </TableCell>
                   </TableRow>
                 ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+
+        <div className="pt-6">
+          <CardTitle>Draft Lead ↔ Organiser Links</CardTitle>
+          <CardDescription>Allow draft leads to manage organisers (live or draft)</CardDescription>
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mt-3">
+            <div>
+              <div className="text-sm mb-2">Draft Lead</div>
+              <Select value={draftLeadPendingId} onValueChange={setDraftLeadPendingId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select draft lead" />
+                </SelectTrigger>
+                <SelectContent>
+                  {pendingLeads.map(l => (
+                    <SelectItem key={l.id} value={l.id}>{pendingLeadLabel(l.id)}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <div className="text-sm mb-2">Live Organiser</div>
+              <Select value={draftLeadToOrganiserId} onValueChange={setDraftLeadToOrganiserId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select organiser (optional)" />
+                </SelectTrigger>
+                <SelectContent>
+                  {organisers.filter(o => o.role === 'organiser').map(o => (
+                    <SelectItem key={o.id} value={o.id}>{o.full_name || o.email}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <div className="text-sm mb-2">Draft Organiser</div>
+              <Select value={draftLeadToPendingId} onValueChange={setDraftLeadToPendingId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select draft organiser (optional)" />
+                </SelectTrigger>
+                <SelectContent>
+                  {pendingOrganisers.map(p => (
+                    <SelectItem key={p.id} value={p.id}>{pendingLabel(p.id)}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-end">
+              <Button onClick={addDraftLeadLink} disabled={loading} className="w-full">
+                {loading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <LinkIcon className="h-4 w-4 mr-2" />}
+                Link draft lead
+              </Button>
+            </div>
+          </div>
+          <div className="pt-2">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Draft Lead</TableHead>
+                  <TableHead>Organiser</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {draftLeadLinks.map(link => {
+                  const child = link.organiser_user_id ? (users.find(u => u.id === link.organiser_user_id)?.full_name || users.find(u => u.id === link.organiser_user_id)?.email || link.organiser_user_id) : pendingLabel(link.organiser_pending_user_id as string)
+                  return (
+                    <TableRow key={link.id}>
+                      <TableCell>{pendingLeadLabel(link.draft_lead_pending_user_id)}</TableCell>
+                      <TableCell>{child}</TableCell>
+                      <TableCell className="text-right">
+                        <Button variant="outline" size="sm" onClick={() => removeDraftLeadLink(link.id)} disabled={loading}>
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
               </TableBody>
             </Table>
           </div>

--- a/supabase/sql/migrations/0006_draft_lead_links_and_lead_patch_close.sql
+++ b/supabase/sql/migrations/0006_draft_lead_links_and_lead_patch_close.sql
@@ -1,0 +1,134 @@
+-- Draft Lead ↔ Organiser (live or draft) links and helpers
+
+-- Ensure helper exists to maintain updated_at (noop if already defined)
+create or replace function update_updated_at_column()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- New table to allow draft lead organisers (pending_users with role lead_organiser)
+-- to be linked to either active organisers (profiles) or draft organisers (pending_users)
+create table if not exists draft_lead_organiser_links (
+  id uuid primary key default gen_random_uuid(),
+  draft_lead_pending_user_id uuid not null references pending_users(id) on delete cascade,
+  organiser_user_id uuid references profiles(id) on delete cascade,
+  organiser_pending_user_id uuid references pending_users(id) on delete cascade,
+  start_date date not null default current_date,
+  end_date date,
+  is_active boolean not null default true,
+  assigned_by uuid references profiles(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint draft_lead_organiser_links_child_chk
+    check ((organiser_user_id is not null)::int + (organiser_pending_user_id is not null)::int = 1)
+);
+
+create index if not exists idx_dlol_draft_lead on draft_lead_organiser_links(draft_lead_pending_user_id, is_active);
+create index if not exists idx_dlol_child_user on draft_lead_organiser_links(organiser_user_id, is_active);
+create index if not exists idx_dlol_child_pending on draft_lead_organiser_links(organiser_pending_user_id, is_active);
+
+create trigger update_dlol_updated_at before update on draft_lead_organiser_links for each row execute function update_updated_at_column();
+
+-- RLS: admin-only for all actions (align with existing admin-managed relationship tables)
+alter table if exists draft_lead_organiser_links enable row level security;
+
+drop policy if exists dlol_admin_all on draft_lead_organiser_links;
+create policy dlol_admin_all on draft_lead_organiser_links for all
+  using (exists (select 1 from profiles p where p.id = auth.uid() and p.role = 'admin'))
+  with check (exists (select 1 from profiles p where p.id = auth.uid() and p.role = 'admin'));
+
+-- Helper to close a lead_organiser ↔ patch assignment
+create or replace function close_lead_patch(p_lead uuid, p_patch uuid)
+returns void language sql as $$
+  update lead_organiser_patch_assignments
+    set effective_to = now()
+    where lead_organiser_id = p_lead and patch_id = p_patch and effective_to is null;
+$$;
+
+-- Extend login helper to migrate draft lead links upon first login
+create or replace function apply_pending_user_on_login()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_email text;
+  v_role text;
+  v_pending_id uuid;
+begin
+  -- Get current user's email (if available)
+  begin
+    v_email := (select auth.email());
+  exception when others then
+    v_email := null;
+  end;
+  if v_email is null then
+    return;
+  end if;
+
+  -- If a pending row exists for this email, apply the role to the profile
+  select id, role into v_pending_id, v_role
+  from pending_users
+  where lower(email) = lower(v_email)
+  order by invited_at desc nulls last, created_at desc
+  limit 1;
+
+  if v_role is null then
+    return;
+  end if;
+
+  -- Set live profile role based on pending record
+  update profiles set role = v_role where id = auth.uid();
+
+  -- If the user is a pending organiser becoming live, migrate any live-lead ↔ draft-organiser links
+  if v_pending_id is not null and v_role = 'organiser' then
+    insert into role_hierarchy(parent_user_id, child_user_id, assigned_by)
+    select l.lead_user_id, auth.uid(), coalesce(l.assigned_by, auth.uid())
+    from lead_draft_organiser_links l
+    where l.pending_user_id = v_pending_id
+      and l.is_active = true
+      and (l.end_date is null or l.end_date >= current_date)
+      and l.lead_user_id is not null
+    on conflict (parent_user_id, child_user_id, start_date) do nothing;
+
+    -- Soft-close the draft links for audit (those which have been migrated)
+    update lead_draft_organiser_links
+      set is_active = false, end_date = current_date
+      where pending_user_id = v_pending_id and is_active = true and (end_date is null or end_date >= current_date) and lead_user_id is not null;
+  end if;
+
+  -- If the user is a pending lead_becoming live, migrate draft lead links
+  if v_pending_id is not null and v_role = 'lead_organiser' then
+    -- Convert draft lead -> live organiser links into live role_hierarchy
+    insert into role_hierarchy(parent_user_id, child_user_id, assigned_by)
+    select auth.uid(), l.organiser_user_id, coalesce(l.assigned_by, auth.uid())
+    from draft_lead_organiser_links l
+    where l.draft_lead_pending_user_id = v_pending_id
+      and l.organiser_user_id is not null
+      and l.is_active = true
+      and (l.end_date is null or l.end_date >= current_date)
+    on conflict (parent_user_id, child_user_id, start_date) do nothing;
+
+    -- Convert draft lead -> draft organiser links into live lead ↔ draft organiser links
+    insert into lead_draft_organiser_links(lead_user_id, pending_user_id, assigned_by)
+    select auth.uid(), l.organiser_pending_user_id, coalesce(l.assigned_by, auth.uid())
+    from draft_lead_organiser_links l
+    where l.draft_lead_pending_user_id = v_pending_id
+      and l.organiser_pending_user_id is not null
+      and l.is_active = true
+      and (l.end_date is null or l.end_date >= current_date)
+    on conflict do nothing;
+
+    -- Soft-close all processed draft lead links
+    update draft_lead_organiser_links
+      set is_active = false, end_date = current_date
+      where draft_lead_pending_user_id = v_pending_id and is_active = true and (end_date is null or end_date >= current_date);
+  end if;
+end;
+$$;


### PR DESCRIPTION
Enable direct patch assignment for Lead Organisers and Draft Lead Organisers, and enhance related hierarchy and project UIs to support these new assignments and improve visibility.

This change allows for more granular control over patch allocation by extending assignment capabilities to Lead Organisers and Draft Lead Organisers. It also introduces the ability for Draft Lead Organisers to manage other Organisers (both active and draft) within the hierarchy. The updated project patch assignment dropdown provides immediate visibility into who is currently assigned to each patch, streamlining the allocation process.

---
<a href="https://cursor.com/background-agent?bcId=bc-59d68ffb-2baa-4e6c-ab49-5b1f14a382d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59d68ffb-2baa-4e6c-ab49-5b1f14a382d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

