### PR TITLE
Changes from background agent bc-bf57e5e7-c648-4f3e-9682-8ddd616caa8d

### DIFF
--- a/supabase/sql/helpers/05_list_tables_missing_select_policy.sql
+++ b/supabase/sql/helpers/05_list_tables_missing_select_policy.sql
@@ -1,0 +1,19 @@
+-- Helper: List public tables that currently have no explicit SELECT (FOR SELECT) policy
+-- Usage: Run in Supabase SQL Editor to identify tables needing read policies
+
+WITH tables AS (
+  SELECT c.oid AS relid, n.nspname AS schema_name, c.relname AS table_name
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relkind = 'r'
+),
+select_policies AS (
+  SELECT polrelid
+  FROM pg_policy
+  WHERE polcmd = 'r'
+)
+SELECT t.schema_name, t.table_name
+FROM tables t
+LEFT JOIN select_policies sp ON sp.polrelid = t.relid
+WHERE sp.polrelid IS NULL
+ORDER BY t.schema_name, t.table_name;

--- a/supabase/sql/migrations/0007_fix_rls_initplan_again.sql
+++ b/supabase/sql/migrations/0007_fix_rls_initplan_again.sql
@@ -1,0 +1,70 @@
+-- Purpose: Re-apply RLS initplan fix after other policy-creating migrations.
+--          Wrap auth.*() and current_setting() calls inside scalar subselects per Supabase guidance.
+-- Reference: https://supabase.com/docs/guides/database/postgres/row-level-security#call-functions-with-select
+
+DO $$
+DECLARE
+    rec RECORD;
+    new_using TEXT;
+    new_check TEXT;
+    changed BOOLEAN;
+BEGIN
+    FOR rec IN (
+        SELECT
+            n.nspname AS schema_name,
+            rel.relname AS table_name,
+            pol.polname AS policy_name,
+            pol.polcmd AS policy_cmd,
+            pg_get_expr(pol.polqual, pol.polrelid) AS using_expr,
+            pg_get_expr(pol.polwithcheck, pol.polrelid) AS check_expr
+        FROM pg_policy pol
+        JOIN pg_class rel ON rel.oid = pol.polrelid
+        JOIN pg_namespace n ON n.oid = rel.relnamespace
+        WHERE n.nspname = 'public'
+          AND (
+            pg_get_expr(pol.polqual, pol.polrelid) ILIKE '%auth.%()%' OR
+            pg_get_expr(pol.polwithcheck, pol.polrelid) ILIKE '%auth.%()%' OR
+            pg_get_expr(pol.polqual, pol.polrelid) ILIKE '%current_setting(%' OR
+            pg_get_expr(pol.polwithcheck, pol.polrelid) ILIKE '%current_setting(%'
+          )
+    ) LOOP
+        changed := FALSE;
+
+        new_using := rec.using_expr;
+        IF new_using IS NOT NULL THEN
+            new_using := regexp_replace(new_using, '\bauth\.uid\(\)', '(select auth.uid())', 'gi');
+            new_using := regexp_replace(new_using, '\bauth\.role\(\)', '(select auth.role())', 'gi');
+            new_using := regexp_replace(new_using, '\bauth\.email\(\)', '(select auth.email())', 'gi');
+            new_using := regexp_replace(new_using, '\bcurrent_setting\s*\(', '(select current_setting(', 'gi');
+            IF new_using IS DISTINCT FROM rec.using_expr THEN
+                changed := TRUE;
+            END IF;
+        END IF;
+
+        new_check := rec.check_expr;
+        IF new_check IS NOT NULL THEN
+            new_check := regexp_replace(new_check, '\bauth\.uid\(\)', '(select auth.uid())', 'gi');
+            new_check := regexp_replace(new_check, '\bauth\.role\(\)', '(select auth.role())', 'gi');
+            new_check := regexp_replace(new_check, '\bauth\.email\(\)', '(select auth.email())', 'gi');
+            new_check := regexp_replace(new_check, '\bcurrent_setting\s*\(', '(select current_setting(', 'gi');
+            IF new_check IS DISTINCT FROM rec.check_expr THEN
+                changed := TRUE;
+            END IF;
+        END IF;
+
+        IF changed THEN
+            RAISE NOTICE 'Altering policy %.% on %.%', rec.policy_name, rec.policy_cmd, rec.schema_name, rec.table_name;
+            IF new_check IS NULL THEN
+                EXECUTE format(
+                    'ALTER POLICY %I ON %I.%I USING (%s);',
+                    rec.policy_name, rec.schema_name, rec.table_name, new_using
+                );
+            ELSE
+                EXECUTE format(
+                    'ALTER POLICY %I ON %I.%I USING (%s) WITH CHECK (%s);',
+                    rec.policy_name, rec.schema_name, rec.table_name, new_using, new_check
+                );
+            END IF;
+        END IF;
+    END LOOP;
+END $$;

--- a/supabase/sql/migrations/0008_split_all_policies_to_write_only.sql
+++ b/supabase/sql/migrations/0008_split_all_policies_to_write_only.sql
@@ -1,0 +1,85 @@
+-- Purpose: Reduce duplicate permissive SELECT policies by removing SELECT from broad "FOR ALL" policies.
+-- Strategy: For each policy in schema public with polcmd = 'a' (ALL), drop it and create three policies
+--           for INSERT, UPDATE, DELETE with identical role targets and expressions. This preserves
+--           write permissions while leaving read (SELECT) to dedicated view policies.
+-- Caveat: This assumes a separate SELECT policy exists. Review after migration for any tables lacking
+--         an explicit SELECT policy and add one if needed.
+
+DO $$
+DECLARE
+    rec RECORD;
+    role_list TEXT;
+    using_expr TEXT;
+    check_expr TEXT;
+    ins_name TEXT;
+    upd_name TEXT;
+    del_name TEXT;
+BEGIN
+    FOR rec IN (
+        SELECT
+            n.nspname AS schema_name,
+            c.relname AS table_name,
+            p.polname AS policy_name,
+            pg_get_expr(p.polqual, p.polrelid) AS using_expr,
+            pg_get_expr(p.polwithcheck, p.polrelid) AS check_expr,
+            p.polrelid,
+            p.polroles
+        FROM pg_policy p
+        JOIN pg_class c ON c.oid = p.polrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND p.polcmd = 'a' -- FOR ALL
+    ) LOOP
+        -- Build role list (TO ...)
+        role_list := NULL;
+        IF rec.polroles IS NOT NULL THEN
+            SELECT string_agg(format('%I', r.rolname), ', ' ORDER BY r.rolname)
+            INTO role_list
+            FROM pg_roles r
+            WHERE r.oid = ANY (rec.polroles);
+        END IF;
+
+        using_expr := COALESCE(rec.using_expr, 'true');
+        check_expr := COALESCE(rec.check_expr, rec.using_expr, 'true');
+
+        ins_name := rec.policy_name || '_ins';
+        upd_name := rec.policy_name || '_upd';
+        del_name := rec.policy_name || '_del';
+
+        RAISE NOTICE 'Rewriting policy % on %.% (FOR ALL -> write-only)', rec.policy_name, rec.schema_name, rec.table_name;
+
+        -- Drop original policy and any previously-created split variants
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I.%I;', rec.policy_name, rec.schema_name, rec.table_name);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I.%I;', ins_name, rec.schema_name, rec.table_name);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I.%I;', upd_name, rec.schema_name, rec.table_name);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I.%I;', del_name, rec.schema_name, rec.table_name);
+
+        -- INSERT policy
+        EXECUTE format(
+            'CREATE POLICY %I ON %I.%I FOR INSERT %s WITH CHECK (%s);',
+            ins_name,
+            rec.schema_name, rec.table_name,
+            COALESCE(CASE WHEN role_list IS NOT NULL THEN 'TO ' || role_list ELSE NULL END, ''),
+            check_expr
+        );
+
+        -- UPDATE policy
+        EXECUTE format(
+            'CREATE POLICY %I ON %I.%I FOR UPDATE %s USING (%s) WITH CHECK (%s);',
+            upd_name,
+            rec.schema_name, rec.table_name,
+            COALESCE(CASE WHEN role_list IS NOT NULL THEN 'TO ' || role_list ELSE NULL END, ''),
+            using_expr,
+            check_expr
+        );
+
+        -- DELETE policy
+        EXECUTE format(
+            'CREATE POLICY %I ON %I.%I FOR DELETE %s USING (%s);',
+            del_name,
+            rec.schema_name, rec.table_name,
+            COALESCE(CASE WHEN role_list IS NOT NULL THEN 'TO ' || role_list ELSE NULL END, ''),
+            using_expr
+        );
+    END LOOP;
+END $$;

--- a/supabase/sql/migrations/0009_restrict_policy_roles_authenticated.sql
+++ b/supabase/sql/migrations/0009_restrict_policy_roles_authenticated.sql
@@ -1,0 +1,72 @@
+-- Purpose: Restrict broad policies (no TO clause) that reference auth.uid() to authenticated users only.
+-- Rationale: Policies without TO apply to all roles (including anon, authenticator, dashboard_user),
+--            which leads to multiple permissive SELECT warnings and unintended exposure.
+--            If a policy references auth.uid(), it implicitly targets authenticated users.
+
+DO $$
+DECLARE
+    rec RECORD;
+    using_expr TEXT;
+    check_expr TEXT;
+    action_sql TEXT;
+BEGIN
+    FOR rec IN (
+        SELECT
+            n.nspname AS schema_name,
+            c.relname AS table_name,
+            p.polname AS policy_name,
+            p.polcmd  AS action, -- r=select, a=all, w=update, d=delete
+            pg_get_expr(p.polqual, p.polrelid) AS using_expr,
+            pg_get_expr(p.polwithcheck, p.polrelid) AS check_expr
+        FROM pg_policy p
+        JOIN pg_class c ON c.oid = p.polrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND p.polroles IS NULL -- no explicit TO roles => all roles
+          AND p.polcmd <> 'a'    -- 'ALL' handled in separate migration
+          AND (
+            pg_get_expr(p.polqual, p.polrelid) ILIKE '%auth.uid()%' OR
+            pg_get_expr(p.polwithcheck, p.polrelid) ILIKE '%auth.uid()%'
+          )
+    ) LOOP
+        using_expr := rec.using_expr;
+        check_expr := rec.check_expr;
+
+        -- Form action
+        action_sql := CASE rec.action
+            WHEN 'r' THEN 'FOR SELECT'
+            WHEN 'w' THEN 'FOR UPDATE'
+            WHEN 'd' THEN 'FOR DELETE'
+            ELSE NULL
+        END;
+
+        IF action_sql IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        RAISE NOTICE 'Restricting policy % on %.% to authenticated', rec.policy_name, rec.schema_name, rec.table_name;
+
+        -- Drop and recreate with TO authenticated
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I.%I;', rec.policy_name, rec.schema_name, rec.table_name);
+
+        IF rec.action = 'r' THEN
+            -- SELECT policies use USING only
+            EXECUTE format(
+                'CREATE POLICY %I ON %I.%I %s TO authenticated USING (%s);',
+                rec.policy_name, rec.schema_name, rec.table_name, action_sql, using_expr
+            );
+        ELSIF rec.action = 'w' THEN
+            -- UPDATE policies use USING and WITH CHECK
+            EXECUTE format(
+                'CREATE POLICY %I ON %I.%I %s TO authenticated USING (%s) WITH CHECK (%s);',
+                rec.policy_name, rec.schema_name, rec.table_name, action_sql, COALESCE(using_expr, 'true'), COALESCE(check_expr, using_expr, 'true')
+            );
+        ELSIF rec.action = 'd' THEN
+            -- DELETE policies use USING only
+            EXECUTE format(
+                'CREATE POLICY %I ON %I.%I %s TO authenticated USING (%s);',
+                rec.policy_name, rec.schema_name, rec.table_name, action_sql, COALESCE(using_expr, 'true')
+            );
+        END IF;
+    END LOOP;
+END $$;


### PR DESCRIPTION
Fix Supabase RLS performance warnings by wrapping `auth.*()` calls and resolve multiple permissive policy warnings by splitting `FOR ALL` policies and restricting roles.

The `multiple_permissive_policies` warnings arise when a table has several RLS policies that grant `SELECT` access for the same role. This PR addresses this by converting `FOR ALL` policies into explicit `FOR INSERT`, `FOR UPDATE`, and `FOR DELETE` policies, and by adding `TO authenticated` to policies that implicitly applied to all roles but relied on `auth.uid()`, thus removing redundant `SELECT` permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf57e5e7-c648-4f3e-9682-8ddd616caa8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf57e5e7-c648-4f3e-9682-8ddd616caa8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

