### PR TITLE
Fix project card ui and data display

### DIFF
--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -423,7 +423,7 @@ function ProjectListCard({ p, onOpenEmployer, onOpenWorker }: { p: ProjectWithRo
             </>
           )}
         </div>
-        <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           {(projectPatches as any[]).length > 0 ? (
             <>
               <span>
@@ -437,7 +437,9 @@ function ProjectListCard({ p, onOpenEmployer, onOpenWorker }: { p: ProjectWithRo
           ) : (
             <span>No patch assigned</span>
           )}
-          <Button size="sm" variant="outline" className="h-6 px-2 ml-auto" onClick={() => setPatchAssignOpen(true)}>Assign patch</Button>
+          {(projectPatches as any[]).length === 0 && (
+            <Button size="sm" variant="outline" className="h-6 px-2 ml-auto" onClick={() => setPatchAssignOpen(true)}>Assign patch</Button>
+          )}
         </div>
       </CardHeader>
       <CardContent className="px-4 pb-4 pt-0 space-y-2">


### PR DESCRIPTION
Hide "Assign patch" button when a patch is assigned and fix UI overlap on project cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-15c2ec1f-44bb-446a-b410-1e3847ffcf5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15c2ec1f-44bb-446a-b410-1e3847ffcf5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

