### PR TITLE
Update project card layout and site access

### DIFF
--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -458,11 +458,14 @@ function ProjectListCard({ p, onOpenEmployer, onOpenWorker }: { p: ProjectWithRo
         </div>
         <div className="pt-1 text-xs text-muted-foreground flex items-center justify-between">
           {delegate?.name ? (
-            <button type="button" className="text-primary hover:underline truncate rounded border border-dashed border-transparent hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 px-1" onClick={() => onOpenWorker(delegate.workerId)} title={delegate.name}>
-              {delegate.name}
-            </button>
+            <div className="truncate">
+              <span className="mr-1">Site delegate:</span>
+              <button type="button" className="text-primary hover:underline truncate rounded border border-dashed border-transparent hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 px-1" onClick={() => onOpenWorker(delegate.workerId)} title={delegate.name}>
+                {delegate.name}
+              </button>
+            </div>
           ) : (
-            <span className="truncate">No delegate recorded</span>
+            <span className="truncate">Site delegate: —</span>
           )}
           {(totals?.totalWorkers || 0) > 0 && (
             <Badge variant="secondary" className="text-[10px]">{totals?.totalWorkers} workers</Badge>


### PR DESCRIPTION
Add 'Site delegate' label to project cards and ensure correct 'Active' EBA status for active employers to improve data clarity, and streamline Sites tab navigation by making the Overview 'Sites' label clickable.

---
<a href="https://cursor.com/background-agent?bcId=bc-78ffc93f-9a5f-437d-aa68-f01bbfeee7c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78ffc93f-9a5f-437d-aa68-f01bbfeee7c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

