### PR TITLE
Investigate slow cached login page load

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -27,7 +27,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         setSession(session);
         setUser(session?.user ?? null);
         setLoading(false);
-        if (session?.user) {
+        if (session?.user && (event === 'SIGNED_IN' || event === 'USER_UPDATED')) {
           // Sync profile and apply any pending role
           setTimeout(() => {
             supabase.rpc('apply_pending_user_on_login');

--- a/src/hooks/useDashboardData.tsx
+++ b/src/hooks/useDashboardData.tsx
@@ -1,13 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { withTimeout } from "@/lib/withTimeout";
+import { useAuth } from "@/hooks/useAuth";
 
 export const useDashboardData = () => {
+  const { session, loading } = useAuth();
+
   return useQuery({
     queryKey: ["dashboard-data"],
+    enabled: !loading && !!session,
+    retry: 1,
+    refetchOnWindowFocus: false,
     queryFn: async () => {
       const errors: string[] = [];
-      const timeoutMs = 8000;
+      const timeoutMs = 4000;
 
       const workersCountP = withTimeout(
         Promise.resolve(supabase.from("workers").select("*", { count: "exact", head: true })),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,10 +26,7 @@ export async function middleware(req: NextRequest) {
     },
   })
 
-  // Touch the session to allow refresh token rotation to set cookies server-side
-  try {
-    await supabase.auth.getSession()
-  } catch {}
+  // Avoid forcing a session fetch on every request; cookie rotation will occur via regular auth flows
 
   return res
 }


### PR DESCRIPTION
Optimize authenticated page loads by gating dashboard data queries, removing redundant session fetches in middleware, and limiting AuthProvider side-effects.

The previous setup caused slow loading for signed-in users because the middleware forced a Supabase session fetch on every request, and the dashboard initiated multiple queries with long timeouts and retries before the user session was fully hydrated. Additionally, the AuthProvider performed heavy RPC calls and profile checks on every token refresh, contributing to the perceived slowness.

---
<a href="https://cursor.com/background-agent?bcId=bc-d588430c-9646-44a4-b226-237a51dce4a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d588430c-9646-44a4-b226-237a51dce4a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

