### PR TITLE
Fix nextjs build type error in page.tsx

### DIFF
--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -40,8 +40,14 @@ function SiteContactsSummary({ projectId, siteIds }: { projectId: string; siteId
         const fn = `${w?.first_name || ''} ${w?.surname || ''}`.trim()
         fullNames[r.worker_id] = fn || r.worker_id
       })
-      const ds = Array.from(new Set((active || []).filter((r: any) => r.name === 'site_delegate').map((r: any) => fullNames[r.worker_id]).filter(Boolean)))
-      const hs = Array.from(new Set((active || []).filter((r: any) => r.name === 'hsr').map((r: any) => fullNames[r.worker_id]).filter(Boolean)))
+      const ds = Array.from(new Set<string>((active || [])
+        .filter((r: any) => r.name === 'site_delegate')
+        .map((r: any) => fullNames[r.worker_id] as string | undefined)
+        .filter((n: string | undefined): n is string => Boolean(n))))
+      const hs = Array.from(new Set<string>((active || [])
+        .filter((r: any) => r.name === 'hsr')
+        .map((r: any) => fullNames[r.worker_id] as string | undefined)
+        .filter((n: string | undefined): n is string => Boolean(n))))
       setDelegates(ds)
       setHsrs(hs)
     }

--- a/src/components/projects/CreateProjectDialog.tsx
+++ b/src/components/projects/CreateProjectDialog.tsx
@@ -149,7 +149,13 @@ export default function CreateProjectDialog() {
           </div>
           <div>
             <Label>Builder (optional)</Label>
-            <SingleEmployerDialogPicker value={builderId} onChange={setBuilderId} />
+            <SingleEmployerDialogPicker
+              label="Builder"
+              selectedId={builderId}
+              onChange={(id: string) => setBuilderId(id)}
+              prioritizedTag="builder"
+              triggerText="Select"
+            />
           </div>
           <JVSelector status={jvStatus} label={jvLabel} onChangeStatus={setJvStatus} onChangeLabel={setJvLabel} />
           <div className="flex justify-end gap-2 pt-2">


### PR DESCRIPTION
Fix Next.js build type errors by correcting array type inference in `page.tsx` and updating `SingleEmployerDialogPicker` props in `CreateProjectDialog.tsx`.

The primary build failure was due to `ds` and `hs` being inferred as `unknown[]` in `src/app/(app)/projects/[projectId]/page.tsx`, causing a type mismatch with `SetStateAction<string[]>`. This was resolved by explicitly typing `Set<string>` and adding a type-guard to the filter. Additionally, a separate type error in `CreateProjectDialog.tsx` was fixed by aligning `SingleEmployerDialogPicker` usage with its expected props.

---
<a href="https://cursor.com/background-agent?bcId=bc-bfc44233-711c-47a9-a002-b0734b8b342f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bfc44233-711c-47a9-a002-b0734b8b342f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

