### PR TITLE
Fix select item value for mapping sheets

### DIFF
--- a/src/app/(app)/patch/walls/page.tsx
+++ b/src/app/(app)/patch/walls/page.tsx
@@ -78,7 +78,7 @@ export default function WallsPage() {
                   <SelectValue placeholder="All sites" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All sites</SelectItem>
+                  <SelectItem value="all">All sites</SelectItem>
                   {(sites as any[]).map((s) => (
                     <SelectItem key={s.id} value={s.id}>{s.name}</SelectItem>
                   ))}

--- a/src/components/projects/mapping/MappingSubcontractorsTable.tsx
+++ b/src/components/projects/mapping/MappingSubcontractorsTable.tsx
@@ -172,14 +172,14 @@ export function MappingSubcontractorsTable({ projectId }: { projectId: string })
   };
 
   const ebaSelect = (row: Row) => (
-    <Select value={row.eba === null ? "" : row.eba ? "yes" : "no"} onValueChange={(v) => setEba(row, v === "" ? null : v === "yes") }>
+    <Select value={row.eba === null ? "unknown" : row.eba ? "yes" : "no"} onValueChange={(v) => setEba(row, v === "unknown" ? null : v === "yes") }>
       <SelectTrigger>
         <SelectValue placeholder="—" />
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="yes">Yes</SelectItem>
         <SelectItem value="no">No</SelectItem>
-        <SelectItem value="">Unknown</SelectItem>
+        <SelectItem value="unknown">Unknown</SelectItem>
       </SelectContent>
     </Select>
   );


### PR DESCRIPTION
Fixes Radix Select.Item errors by replacing empty string values with non-empty sentinels.

The `Select.Item` component throws an error if its `value` prop is an empty string, as this value is reserved for clearing the selection. This PR updates the "Unknown" option in the mapping subcontractors table and the "All sites" option on the walls page to use unique string values instead of an empty string, resolving the page rendering failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce0cee77-1991-4809-a186-367a3d77c6c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce0cee77-1991-4809-a186-367a3d77c6c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

