### PR TITLE
Fix project mapping sheet display and data

### DIFF
--- a/src/app/print.css
+++ b/src/app/print.css
@@ -12,6 +12,14 @@
   /* Hide interactive chrome */
   button, input, select, textarea, [role="button"], .shadcn-button { display: none !important; }
 
+  /* Force black on white for print */
+  html, body, #__next, main, section, div, table, th, td, span, p, h1, h2, h3, h4, h5, h6 {
+    color: #000 !important;
+    background: #fff !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
   /* High-contrast borders */
   .print-border { border: 1px solid #000 !important; }
   .print-table { border-collapse: collapse !important; width: 100% !important; }

--- a/supabase/sql/migrations/0010_get_trade_type_enum.sql
+++ b/supabase/sql/migrations/0010_get_trade_type_enum.sql
@@ -1,0 +1,13 @@
+-- Expose enum values for public.trade_type via RPC
+-- Safe, read-only helper for clients
+create or replace function public.get_trade_type_enum()
+returns setof text
+language sql
+stable
+as $$
+  select unnest(enum_range(null::public.trade_type))::text;
+$$;
+
+-- Grant execute to authenticated and anon roles if needed
+grant execute on function public.get_trade_type_enum() to anon, authenticated, service_role;
+


### PR DESCRIPTION
Dynamically load and group trade types, simplify the Company field, remove the Stage column, and enforce black-on-white print styling on the mapping sheets page to improve trade matching and UI clarity.

The previous trade matching logic relied on a static list and could miscategorize trades (e.g., "other/tower_crane" instead of "Structure/Tower Crane") if the `stage` was null or inconsistent. This PR introduces dynamic loading of `public.trade_type` enums and infers display stages based on historical data, ensuring correct categorization and future-proofing against enum changes, while preserving existing database `stage` values on save. It also addresses the duplicated "Company" field and redundant "Stage" column for a cleaner UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a0e3b73-6e53-4a99-ba9b-0ecea837863c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a0e3b73-6e53-4a99-ba9b-0ecea837863c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

