### PR TITLE
Review agent work and check history

### DIFF
--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -714,6 +714,10 @@ export default function ProjectDetailPage() {
                   const Comp = require("@/components/projects/mapping/MappingSheetPage1").MappingSheetPage1;
                   return <Comp projectId={project.id} />
                 })()}
+                {(() => {
+                  const Subs = require("@/components/projects/mapping/MappingSubcontractorsTable").MappingSubcontractorsTable;
+                  return <Subs projectId={project.id} />
+                })()}
               </div>
             </div>
           )}


### PR DESCRIPTION
Restore `MappingSubcontractorsTable` to the main mapping sheets tab to fix its accidental removal.

The `MappingSubcontractorsTable` was removed from `src/app/(app)/projects/[projectId]/page.tsx` by a merge commit (third back, PR #120). A subsequent commit (second last) intended to restore it, but it was only present on the print version of the mapping sheets, not the main tab, leading to the restoration attempt failing to appear on the form. This PR explicitly adds the table back to the main tab, mirroring the print page's structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-15dd4a19-3ad9-45f3-81c6-c5d227e369b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15dd4a19-3ad9-45f3-81c6-c5d227e369b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

